### PR TITLE
Various improvements proposed

### DIFF
--- a/c/amcl.h
+++ b/c/amcl.h
@@ -2327,6 +2327,12 @@ extern void FF_shr(BIG *x,int n);
 	@param n size of FF in BIGs
  */
 extern void FF_output(BIG *x,int n);
+/**	@brief Formats and outputs an FF to the console, in raw form
+ *
+ 	@param x FF instance to be printed
+ 	@param n size of FF in BIGs
+ */
+extern void FF_rawoutput(BIG *x,int n);
 /**	@brief Formats and outputs an FF instance to an octet string
  *
 	Converts an FF to big-endian base 256 form.

--- a/c/amcl.h
+++ b/c/amcl.h
@@ -817,6 +817,13 @@ extern void BIG_fromBytes(BIG x,char *a);
 	@param s byte array length
  */
 extern void BIG_fromBytesLen(BIG x,char *a,int s);
+/**@brief Convert to DBIG number from byte array of given length
+ *
+   @param x DBIG number
+   @param a byte array
+   @param s byte array length
+ */
+extern void BIG_dfromBytesLen(DBIG x,char *a,int s);
 /**	@brief Outputs a DBIG number to the console
  *
 	@param x a DBIG number
@@ -1060,8 +1067,9 @@ extern int BIG_dnbits(DBIG x);
 	Slow but rarely used
 	@param x BIG number to be reduced mod n
 	@param n The modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_mod(BIG x,BIG n);
+extern int BIG_mod(BIG x,BIG n);
 /**	@brief Divide x by n - output normalised
  *
 	Slow but rarely used
@@ -1138,8 +1146,9 @@ extern void BIG_randomnum(BIG x,BIG n,csprng *r);
 	@param y BIG number
 	@param z BIG number
 	@param n The BIG Modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_modmul(BIG x,BIG y,BIG z,BIG n);
+extern int BIG_modmul(BIG x,BIG y,BIG z,BIG n);
 /**	@brief  Calculate x=y/z mod n
  *
 	Slow method for modular division
@@ -1147,24 +1156,27 @@ extern void BIG_modmul(BIG x,BIG y,BIG z,BIG n);
 	@param y BIG number
 	@param z BIG number
 	@param n The BIG Modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_moddiv(BIG x,BIG y,BIG z,BIG n);
+extern int BIG_moddiv(BIG x,BIG y,BIG z,BIG n);
 /**	@brief  Calculate x=y^2 mod n
  *
 	Slow method for modular squaring
 	@param x BIG number, on exit = y^2 mod n
 	@param y BIG number
 	@param n The BIG Modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_modsqr(BIG x,BIG y,BIG n);
+extern int BIG_modsqr(BIG x,BIG y,BIG n);
 /**	@brief  Calculate x=-y mod n
  *
 	Modular negation
 	@param x BIG number, on exit = -y mod n
 	@param y BIG number
 	@param n The BIG Modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_modneg(BIG x,BIG y,BIG n);
+extern int BIG_modneg(BIG x,BIG y,BIG n);
 /**	@brief  Calculate jacobi Symbol (x/y)
  *
 	@param x BIG number
@@ -1178,8 +1190,9 @@ extern int BIG_jacobi(BIG x,BIG y);
 	@param x BIG number, on exit = 1/y mod n
 	@param y BIG number
 	@param n The BIG Modulus
+	@return 0 in case of success, 1 in case of error
  */
-extern void BIG_invmodp(BIG x,BIG y,BIG n);
+extern int BIG_invmodp(BIG x,BIG y,BIG n);
 /** @brief Calculate x=x mod 2^m
  *
 	Truncation 

--- a/c/amcl.h
+++ b/c/amcl.h
@@ -1067,9 +1067,8 @@ extern int BIG_dnbits(DBIG x);
 	Slow but rarely used
 	@param x BIG number to be reduced mod n
 	@param n The modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_mod(BIG x,BIG n);
+extern void BIG_mod(BIG x,BIG n);
 /**	@brief Divide x by n - output normalised
  *
 	Slow but rarely used
@@ -1146,9 +1145,8 @@ extern void BIG_randomnum(BIG x,BIG n,csprng *r);
 	@param y BIG number
 	@param z BIG number
 	@param n The BIG Modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_modmul(BIG x,BIG y,BIG z,BIG n);
+extern void BIG_modmul(BIG x,BIG y,BIG z,BIG n);
 /**	@brief  Calculate x=y/z mod n
  *
 	Slow method for modular division
@@ -1156,27 +1154,24 @@ extern int BIG_modmul(BIG x,BIG y,BIG z,BIG n);
 	@param y BIG number
 	@param z BIG number
 	@param n The BIG Modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_moddiv(BIG x,BIG y,BIG z,BIG n);
+extern void BIG_moddiv(BIG x,BIG y,BIG z,BIG n);
 /**	@brief  Calculate x=y^2 mod n
  *
 	Slow method for modular squaring
 	@param x BIG number, on exit = y^2 mod n
 	@param y BIG number
 	@param n The BIG Modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_modsqr(BIG x,BIG y,BIG n);
+extern void BIG_modsqr(BIG x,BIG y,BIG n);
 /**	@brief  Calculate x=-y mod n
  *
 	Modular negation
 	@param x BIG number, on exit = -y mod n
 	@param y BIG number
 	@param n The BIG Modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_modneg(BIG x,BIG y,BIG n);
+extern void BIG_modneg(BIG x,BIG y,BIG n);
 /**	@brief  Calculate jacobi Symbol (x/y)
  *
 	@param x BIG number
@@ -1190,9 +1185,8 @@ extern int BIG_jacobi(BIG x,BIG y);
 	@param x BIG number, on exit = 1/y mod n
 	@param y BIG number
 	@param n The BIG Modulus
-	@return 0 in case of success, 1 in case of error
  */
-extern int BIG_invmodp(BIG x,BIG y,BIG n);
+extern void BIG_invmodp(BIG x,BIG y,BIG n);
 /** @brief Calculate x=x mod 2^m
  *
 	Truncation 

--- a/c/big.c
+++ b/c/big.c
@@ -1010,16 +1010,13 @@ int BIG_dnbits(BIG a)
 
 /* Set b=b mod c */
 /* SU= 16 */
-int BIG_mod(BIG b,BIG c)
+void BIG_mod(BIG b,BIG c)
 {
     int k=0;
 
-    if (BIG_iszilch(c))
-        return 1;
-
     BIG_norm(b);
     if (BIG_comp(b,c)<0)
-        return 0;
+        return;
     do
     {
         BIG_fshl(c,1);
@@ -1037,7 +1034,6 @@ int BIG_mod(BIG b,BIG c)
         }
         k--;
     }
-    return 0;
 }
 /* Set a=b mod c, b is destroyed. Slow but rarely used. */
 /* SU= 96 */
@@ -1264,51 +1260,40 @@ void BIG_randomnum(BIG m,BIG q,csprng *rng)
 
 /* Set r=a*b mod m */
 /* SU= 96 */
-int BIG_modmul(BIG r,BIG a,BIG b,BIG m)
+void BIG_modmul(BIG r,BIG a,BIG b,BIG m)
 {
-    if (BIG_iszilch(m))
-        return 1;
     DBIG d;
     BIG_mod(a,m);
     BIG_mod(b,m);
 //BIG_norm(a); BIG_norm(b);
     BIG_mul(d,a,b);
     BIG_dmod(r,d,m);
-    return 0;
 }
 
 /* Set a=a*a mod m */
 /* SU= 88 */
-int BIG_modsqr(BIG r,BIG a,BIG m)
+void BIG_modsqr(BIG r,BIG a,BIG m)
 {
-    if (BIG_iszilch(m))
-        return 1;
     DBIG d;
     BIG_mod(a,m);
 //BIG_norm(a);
     BIG_sqr(d,a);
     BIG_dmod(r,d,m);
-    return 0;
 }
 
 /* Set r=-a mod m */
 /* SU= 16 */
-int BIG_modneg(BIG r,BIG a,BIG m)
+void BIG_modneg(BIG r,BIG a,BIG m)
 {
-    if (BIG_iszilch(m))
-        return 1;
     BIG_mod(a,m);
     BIG_sub(r,m,a);
     BIG_mod(r,m);
-    return 0;
 }
 
 /* Set a=a/b mod m */
 /* SU= 136 */
-int BIG_moddiv(BIG r,BIG a,BIG b,BIG m)
+void BIG_moddiv(BIG r,BIG a,BIG b,BIG m)
 {
-    if (BIG_iszilch(m))
-        return 1;
     DBIG d;
     BIG z;
     BIG_mod(a,m);
@@ -1316,15 +1301,12 @@ int BIG_moddiv(BIG r,BIG a,BIG b,BIG m)
 //BIG_norm(a); BIG_norm(z);
     BIG_mul(d,a,z);
     BIG_dmod(r,d,m);
-    return 0;
 }
 
 /* Get jacobi Symbol (a/p). Returns 0, 1 or -1 */
 /* SU= 216 */
 int BIG_jacobi(BIG a,BIG p)
 {
-    if (BIG_iszilch(p))
-        return -1;
     int n8,k,m=0;
     BIG t,x,n,zilch,one;
     BIG_one(one);
@@ -1361,10 +1343,8 @@ int BIG_jacobi(BIG a,BIG p)
 
 /* Set r=1/a mod p. Binary method */
 /* SU= 240 */
-int BIG_invmodp(BIG r,BIG a,BIG p)
+void BIG_invmodp(BIG r,BIG a,BIG p)
 {
-    if (BIG_iszilch(p))
-        return 1;
     BIG u,v,x1,x2,t,one;
     BIG_mod(a,p);
     BIG_copy(u,a);
@@ -1424,7 +1404,6 @@ int BIG_invmodp(BIG r,BIG a,BIG p)
         BIG_copy(r,x1);
     else
         BIG_copy(r,x2);
-    return 0;
 }
 
 /* set x = x mod 2^m */


### PR DESCRIPTION
- Add a prototype for the function "void FF_rawoutput(BIG *x,int n)" in amcl.h with source code in ff.c
- Modified the following functions BIG_mod, BIG_moddiv, BIG_modmul, BIG_modsqr, BIG_modneg, BIG_invmodp from "void" to "int" and added a check that the modulo is different from zero.
- Creation of the function BIG_dfromBytesLen, to write in a DBIG variable an external input (needed for testing).
- Fixed bug in BIG_modneg that, in case the second argument is a multiple of the third argument, didn't return 0.
