### PR TITLE
Allow config*.py to work on Darwin.

### DIFF
--- a/version3/c/config.py
+++ b/version3/c/config.py
@@ -5,6 +5,9 @@ deltext=""
 if sys.platform.startswith("linux")  :
 	deltext="rm"
 	copytext="cp"
+if sys.platform.startswith("darwin")  :
+	deltext="rm"
+	copytext="cp"
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"

--- a/version3/c/config16.py
+++ b/version3/c/config16.py
@@ -5,6 +5,9 @@ deltext=""
 if sys.platform.startswith("linux")  :
 	deltext="rm"
 	copytext="cp"
+if sys.platform.startswith("darwin")  :
+	deltext="rm"
+	copytext="cp"
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"

--- a/version3/c/config32.py
+++ b/version3/c/config32.py
@@ -5,6 +5,9 @@ deltext=""
 if sys.platform.startswith("linux")  :
 	deltext="rm"
 	copytext="cp"
+if sys.platform.startswith("darwin")  :
+	deltext="rm"
+	copytext="cp"
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"

--- a/version3/c/config64.py
+++ b/version3/c/config64.py
@@ -5,6 +5,9 @@ deltext=""
 if sys.platform.startswith("linux")  :
 	deltext="rm"
 	copytext="cp"
+if sys.platform.startswith("darwin")  :
+	deltext="rm"
+	copytext="cp"
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"


### PR DESCRIPTION
This simply adds the `rm` and `cp` for Darwin, in the config*.py scripts.

This works on my 64-bit Mac OS X, and _should_ be fine in general.