### PR TITLE
Explicitly check for __int128 availability

### DIFF
--- a/version3/c/arch.h
+++ b/version3/c/arch.h
@@ -110,12 +110,9 @@
 /**< Note - no 128-bit type available    */
 #else
 #define chunk int64_t		/**< C type corresponding to word length */
-#ifdef __GNUC__
-#define dchunk __int128		/**< Always define double length chunk type if available - GCC supports 128 bit type  ??? */
-#endif
 
-#ifdef __clang__
-#define dchunk __int128
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
+#define dchunk __int128                /**< Always define double length chunk type if available (supported by GCC & Clang on 64-bit architectures) */
 #endif
 
 #endif


### PR DESCRIPTION
This allows to compile the 64-bit C version to wasm (just changing gcc -> emcc, ar -> emar in config64.py). 