### PR TITLE
Let FP constructor behave the same way for number and BIG

### DIFF
--- a/version3/js/fp.js
+++ b/version3/js/fp.js
@@ -31,7 +31,7 @@ var FP = function(ctx) {
         } else {
             this.f = new ctx.BIG(x);
 			this.XES = 1;
-			if (x!=0)
+			if (!this.f.iszilch())
 				this.nres();
         }
     };


### PR DESCRIPTION
I was having a hard time trying to understand if the argument in the FP can also be BIG, since the code flow is different for `x: number` and `x: BIG`. Looking at the other implementations, it turns out running `nres()` on `x = BIG(0)` does not harm.

I think this PR changes no behavior other than avoiding the call to `nres()` for `BIG(0)`. 

The other way to solve this issue would be to always call `nres()`, like I see it in Java. Maybe it is even better to move the zero-check into `nres()`. Let me know what you think and I'll adapt.