### PR TITLE
Remove unnecessary `return this.nres()`

### DIFF
--- a/version3/js/fp.js
+++ b/version3/js/fp.js
@@ -185,7 +185,7 @@ var FP = function(ctx) {
         /* set this=1 */
         one: function() {
             this.f.one();
-            return this.nres();
+            this.nres();
         },
 
         /* normalise this */


### PR DESCRIPTION
`this.nres()` returns nothing, so one() does not need to have a return statement. This makes the easier to understand (no return value)