### PR TITLE
avoid un-neccessary copying in is_infinity and use a match statement to avoid a potential bug

### DIFF
--- a/version3/rust/src/ecp.rs
+++ b/version3/rust/src/ecp.rs
@@ -192,20 +192,11 @@ impl ECP {
 
     /* test for O point-at-infinity */
     pub fn is_infinity(&self) -> bool {
-        let xx = FP::new_copy(&self.x);
-        let zz = FP::new_copy(&self.z);
-
-        if CURVETYPE == CurveType::EDWARDS {
-            let yy = FP::new_copy(&self.y);
-            return xx.iszilch() && yy.equals(&zz);
+        match CURVETYPE {
+            CurveType::EDWARDS=> self.x.iszilch() && self.y.iszilch(),
+            CurveType::WEIERSTRASS => self.x.iszilch() && self.z.iszilch(),
+            CurveType::MONTGOMERY => self.z.iszilch(),
         }
-        if CURVETYPE == CurveType::WEIERSTRASS {
-            return xx.iszilch() && zz.iszilch();
-        }
-        if CURVETYPE == CurveType::MONTGOMERY {
-            return zz.iszilch();
-        }
-        return true;
     }
 
     /* Conditional swap of P and Q dependant on d */

--- a/version3/rust/src/ecp2.rs
+++ b/version3/rust/src/ecp2.rs
@@ -96,9 +96,7 @@ impl ECP2 {
 
     /* Test this=O? */
     pub fn is_infinity(&self) -> bool {
-        let xx = FP2::new_copy(&self.x);
-        let zz = FP2::new_copy(&self.z);
-        return xx.iszilch() && zz.iszilch();
+        self.x.iszilch() && self.z.iszilch()
     }
 
     /* copy self=P */


### PR DESCRIPTION
Signed-off-by: lovesh harchandani <lovesh.bond@gmail.com>