### PR TITLE
Add copy constructor to ECP* in JavaScript

### DIFF
--- a/version3/js/ecp.js
+++ b/version3/js/ecp.js
@@ -23,13 +23,21 @@ var ECP = function(ctx) {
     "use strict";
 
     /* Constructor */
-    var ECP = function() {
-        this.x = new ctx.FP(0);
-        this.y = new ctx.FP(1);
-        if (ECP.CURVETYPE != ECP.EDWARDS) {
-            this.z = new ctx.FP(0);
+    var ECP = function(input) {
+        if (input instanceof ECP) {
+            // copy constructor
+            this.x = new ctx.FP(input.x);
+            this.y = new ctx.FP(input.y);
+            this.z = new ctx.FP(input.z);
         } else {
-            this.z = new ctx.FP(1);
+            // default constructor (point at infinity)
+            this.x = new ctx.FP(0);
+            this.y = new ctx.FP(1);
+            if (ECP.CURVETYPE != ECP.EDWARDS) {
+                this.z = new ctx.FP(0);
+            } else {
+                this.z = new ctx.FP(1);
+            }
         }
     };
 

--- a/version3/js/ecp2.js
+++ b/version3/js/ecp2.js
@@ -22,11 +22,19 @@
 var ECP2 = function(ctx) {
     "use strict";
 
-    /* Constructor, set this=O */
-    var ECP2 = function() {
-        this.x = new ctx.FP2(0);
-        this.y = new ctx.FP2(1);
-        this.z = new ctx.FP2(0);
+    /* Constructor */
+    var ECP2 = function(input) {
+        if (input instanceof ECP2) {
+            // copy constructor
+            this.x = new ctx.FP2(input.x);
+            this.y = new ctx.FP2(input.y);
+            this.z = new ctx.FP2(input.z);
+        } else {
+            // default constructor (point at infinity)
+            this.x = new ctx.FP2(0);
+            this.y = new ctx.FP2(1);
+            this.z = new ctx.FP2(0);
+        }
     };
 
     ECP2.prototype = {

--- a/version3/js/ecp4.js
+++ b/version3/js/ecp4.js
@@ -22,11 +22,19 @@
 var ECP4 = function(ctx) {
     "use strict";
 
-    /* Constructor, set this=O */
-    var ECP4 = function() {
-        this.x = new ctx.FP4(0);
-        this.y = new ctx.FP4(1);
-        this.z = new ctx.FP4(0);
+    /* Constructor */
+    var ECP4 = function(input) {
+        if (input instanceof ECP4) {
+            // copy constructor
+            this.x = new ctx.FP4(input.x);
+            this.y = new ctx.FP4(input.y);
+            this.z = new ctx.FP4(input.z);
+        } else {
+            // default constructor (point at infinity)
+            this.x = new ctx.FP4(0);
+            this.y = new ctx.FP4(1);
+            this.z = new ctx.FP4(0);
+        }
     };
 
     ECP4.prototype = {

--- a/version3/js/ecp8.js
+++ b/version3/js/ecp8.js
@@ -22,11 +22,19 @@
 var ECP8 = function(ctx) {
     "use strict";
 
-    /* Constructor, set this=O */
-    var ECP8 = function() {
-        this.x = new ctx.FP8(0);
-        this.y = new ctx.FP8(1);
-        this.z = new ctx.FP8(0);
+    /* Constructor */
+    var ECP8 = function(input) {
+        if (input instanceof ECP8) {
+            // copy constructor
+            this.x = new ctx.FP8(input.x);
+            this.y = new ctx.FP8(input.y);
+            this.z = new ctx.FP8(input.z);
+        } else {
+            // default constructor (point at infinity)
+            this.x = new ctx.FP8(0);
+            this.y = new ctx.FP8(1);
+            this.z = new ctx.FP8(0);
+        }
     };
 
     ECP8.prototype = {


### PR DESCRIPTION
Makes caller code a bit nicer. Before:

```js
const c = new ctx.ECP();
c.copy(a)
c.add(b);
```

Now:

```js
const c = new ctx.ECP(a);
c.add(b);
```

The constructor API is the same as Java now.