### PR TITLE
JS: Fix and improve code style in pair*.js

### DIFF
--- a/version3/js/pair.js
+++ b/version3/js/pair.js
@@ -583,7 +583,7 @@ var PAIR = function(ctx) {
 		n3.pmul(3);
 		n3.norm();
 		return n3.nbits();
-	},
+	};
 
     /* GLV method */
     PAIR.glv = function(e) {

--- a/version3/js/pair.js
+++ b/version3/js/pair.js
@@ -127,7 +127,7 @@ var PAIR = function(ctx) {
             return r;
         },
 
-/* prepare for multi-pairing */
+		/* prepare for multi-pairing */
 		initmp: function() {
 			var r=[];
 			for (var i=0;i<ctx.ECP.ATE_BITS;i++)
@@ -135,7 +135,7 @@ var PAIR = function(ctx) {
 			return r;
 		},
 
-/* basic Miller loop */
+		/* basic Miller loop */
 		miller: function(r) {
 			var res=new ctx.FP12(1);
 			for (var i=ctx.ECP.ATE_BITS-1; i>=1; i--)
@@ -151,7 +151,7 @@ var PAIR = function(ctx) {
 			return res;
 		},
 
-/* Accumulate another set of line functions for n-pairing */
+		/* Accumulate another set of line functions for n-pairing */
 		another: function(r,P1,Q1) {
 
 			var f;
@@ -309,8 +309,7 @@ var PAIR = function(ctx) {
             return r;
         },
 
-        /* Optimal R-ate double pairing e(P,Q).e(R,S) */
-	
+        /* Optimal R-ate double pairing e(P,Q).e(R,S) */	
         ate2: function(P1, Q1, R1, S1) {
             var fa, fb, f, x, n, n3, K, lv, lv2,
                 Qx, Qy, Sx, Sy, A, B, NP,NR,r, nb, bt,
@@ -565,9 +564,8 @@ var PAIR = function(ctx) {
         }
     };
 
-/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
-	PAIR.lbits = function(n3,n)
-	{
+	/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
+	PAIR.lbits = function(n3,n) {
 		n.rcopy(ctx.ROM_CURVE.CURVE_Bnx);
 		if (ctx.ECP.CURVE_PAIRING_TYPE==ctx.ECP.BN)
 		{

--- a/version3/js/pair192.js
+++ b/version3/js/pair192.js
@@ -125,7 +125,7 @@ var PAIR192 = function(ctx) {
             return r;
         },
 
-/* prepare for multi-pairing */
+		/* prepare for multi-pairing */
 		initmp: function() {
 			var r=[];
 			for (var i=0;i<ctx.ECP.ATE_BITS;i++)
@@ -133,7 +133,7 @@ var PAIR192 = function(ctx) {
 			return r;
 		},
 
-/* basic Miller loop */
+		/* basic Miller loop */
 		miller: function(r) {
 			var res=new ctx.FP24(1);
 			for (var i=ctx.ECP.ATE_BITS-1; i>=1; i--)
@@ -149,16 +149,15 @@ var PAIR192 = function(ctx) {
 			return res;
 		},
 
-/* Accumulate another set of line functions for n-pairing */
+		/* Accumulate another set of line functions for n-pairing */
 		another: function(r,P1,Q1) {
-
 			var f;
 			var n=new ctx.BIG(0);
 			var n3=new ctx.BIG(0);
 			var lv,lv2;
 			var bt;
 
-// P is needed in affine form for line function, Q for (Qx,Qy) extraction
+			// P is needed in affine form for line function, Q for (Qx,Qy) extraction
 			var P=new ctx.ECP4(); P.copy(P1); P.affine();
 			var Q=new ctx.ECP(); Q.copy(Q1); Q.affine();
 
@@ -415,9 +414,8 @@ var PAIR192 = function(ctx) {
         }
     };
 
-/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
-	PAIR192.lbits = function(n3,n)
-	{
+	/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
+	PAIR192.lbits = function(n3,n) {
 		n.rcopy(ctx.ROM_CURVE.CURVE_Bnx);
 		n3.copy(n);
 		n3.pmul(3);

--- a/version3/js/pair192.js
+++ b/version3/js/pair192.js
@@ -421,7 +421,7 @@ var PAIR192 = function(ctx) {
 		n3.pmul(3);
 		n3.norm();
 		return n3.nbits();
-	},
+	};
 
     /* GLV method */
     PAIR192.glv = function(e) {

--- a/version3/js/pair256.js
+++ b/version3/js/pair256.js
@@ -125,7 +125,7 @@ var PAIR256 = function(ctx) {
             return r;
         },
 
-/* prepare for multi-pairing */
+		/* prepare for multi-pairing */
 		initmp: function() {
 			var r=[];
 			for (var i=0;i<ctx.ECP.ATE_BITS;i++)
@@ -133,7 +133,7 @@ var PAIR256 = function(ctx) {
 			return r;
 		},
 
-/* basic Miller loop */
+		/* basic Miller loop */
 		miller: function(r) {
 			var res=new ctx.FP48(1);
 			for (var i=ctx.ECP.ATE_BITS-1; i>=1; i--)
@@ -149,16 +149,15 @@ var PAIR256 = function(ctx) {
 			return res;
 		},
 
-/* Accumulate another set of line functions for n-pairing */
+		/* Accumulate another set of line functions for n-pairing */
 		another: function(r,P1,Q1) {
-
 			var f;
 			var n=new ctx.BIG(0);
 			var n3=new ctx.BIG(0);
 			var lv,lv2;
 			var bt;
 
-// P is needed in affine form for line function, Q for (Qx,Qy) extraction
+			// P is needed in affine form for line function, Q for (Qx,Qy) extraction
 			var P=new ctx.ECP8(); P.copy(P1); P.affine();
 			var Q=new ctx.ECP(); Q.copy(Q1); Q.affine();
 
@@ -486,9 +485,8 @@ var PAIR256 = function(ctx) {
         }
     };
 
-/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
-	PAIR256.lbits = function(n3,n)
-	{
+	/* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
+	PAIR256.lbits = function(n3,n) {
 		n.rcopy(ctx.ROM_CURVE.CURVE_Bnx);
 		n3.copy(n);
 		n3.pmul(3);

--- a/version3/js/pair256.js
+++ b/version3/js/pair256.js
@@ -492,7 +492,7 @@ var PAIR256 = function(ctx) {
 		n3.pmul(3);
 		n3.norm();
 		return n3.nbits();
-	},
+	};
 
     /* GLV method */
     PAIR256.glv = function(e) {


### PR DESCRIPTION
The first commit is just whitespacing for readability. The second commit is a fix of an unintended comma.

The code worked before since

```js
(a = function() { ... }, b = function() { ...} ) // unused expression
```

behaves like

```js
a = function() { ... };
b = function() { ... };
```
