### PR TITLE
Create Travis build matrix with one build per language 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-language: rust
-rust:
-  - stable
-before_script: cd version3/rust
+dist: xenial
+language: minimal
+
+env:
+  matrix:
+    - AMCL_LANG=js
+    - AMCL_LANG=rust
+
 script:
-  - cargo build --all-features
-deploy:
-  provider: cargo
-  token: "1YhwbnDDEE2ZdX8P7g4U9WY3uzKTZHvIk5qKEivXYQbQwtLsugOlh8plPhFuL9M6lQeiHX7GeuQkevsymgXHrXVV5QFB7JtsJmh4tJcIiJ8z+9YWchHmCLRkXWoWgoXxwEGIne48KT3At43gCKJGNFGmYAl00XtgiQ1SAfop0LmImrWWHyDIAxeou6GBSg+S2Gz5+AePf3HDnXCfgX2f+tw/SGlEi6LDAtyoU7+yF584g9d5PK6Ctm7GMCdS4M65mqhcqUkrqy4jGomAkf57/j4zauj2ISmyHcmfkKNFvK2qFlf/vy65hacFV3+nIUYvcAv8aasT5Qx895LsQ3xXmCIJnorqd1c7xeafjQudLwpDlyJs5j82NZUIQn+mMkCuSj5g686gpfuKMNs0Gthl2Z7IzmQWiP5PgDZd/QEx/4Q4jUoy8CtrZu6BCxAK7muLLWaI91gWpducaJKZ6dVHZ5tBz7XHG7NFpqRssCUfIMhganVHQ6HRzeADqYXswkH005uexmKRKBvXFZjvbz3e21uSY4HTWZwmcQH+BWEDjfIqY4g0BOUukZH/bOsHYIcKsRT6eanHCsiDKpGbcRB+s6qSquFgtRohUbncUTU1UpaGGPqRiT21WzkbGhVS/oA9uS+NDgB824f9aNShZ0havjCUEpbIfWV+gQdl/j66aUo="
-  on:
-     branch: master
+  - ./scripts/travis.sh
+
+notifications:
+  email: false

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+case "$AMCL_LANG" in
+  js)
+    echo "Coming soon :)"
+    ;;
+  rust)
+    ./scripts/travis_rust.sh
+    ;;
+  *)
+    echo "Unknown value for AMCL_LANG"
+    exit 1
+esac

--- a/scripts/travis_rust.sh
+++ b/scripts/travis_rust.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+TOOLCHAIN="stable"
+
+#
+# Install
+#
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "$TOOLCHAIN" -y
+# shellcheck disable=SC1090
+source "$HOME/.cargo/env"
+
+(
+  cd version3/rust
+
+  #
+  # Build
+  #
+  cargo build --all-features
+
+  #
+  # Deploy
+  #
+  if [[ "$TRAVIS_BRANCH" == "master" ]] && [[ "$TRAVIS_TAG" == "" ]] && [[ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]]; then
+      echo "TODO: make crates.io deployment work again"
+  fi
+)


### PR DESCRIPTION
* Upgrade Travis to xenial
* Create a build matrix with one build per language
* Deactivates crates.io deployment ([which is currently broken](https://travis-ci.org/miracl/amcl/builds/551691740)) to make build green again
* Add basic .editorconfig to get more consistent whitespacing