### PR TITLE
Add JavaScript unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-language: minimal
+language: generic
 
 env:
   matrix:

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -4,7 +4,7 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 case "$AMCL_LANG" in
   js)
-    echo "Coming soon :)"
+    ./scripts/travis_js.sh
     ;;
   rust)
     ./scripts/travis_rust.sh

--- a/scripts/travis_js.sh
+++ b/scripts/travis_js.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+NODEJS_VERSION="8"
+
+(
+  cd version3/js
+
+  #
+  # Install
+  #
+
+  # shellcheck disable=SC1090
+  . "$NVM_DIR/nvm.sh"
+  nvm use "$NODEJS_VERSION"
+  yarn install
+
+  #
+  # Test
+  #
+
+  # We have 2 cores available (https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system),
+  # so override jest default (cores - 1).
+  yarn test --ci --maxWorkers 2
+)

--- a/version3/js/aes.spec.js
+++ b/version3/js/aes.spec.js
@@ -1,0 +1,268 @@
+const { CTX } = require("./ctx");
+
+describe("AES", () => {
+  const ctx = new CTX("ED25519");
+
+  it("can be constructed", () => {
+    const aes = new ctx.AES();
+    expect(aes).toBeTruthy();
+  });
+
+  describe("ecb_encrypt", () => {
+    it("can encrypt a single block (Botan test vectors)", () => {
+      const aes = new ctx.AES();
+
+      // Test vectors from
+      // https://github.com/randombit/botan/blob/2.10.0/src/tests/data/block/aes.vec
+
+      // AES-128
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("000102030405060708090A0B0C0D0E0F", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("00112233445566778899AABBCCDDEEFF", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("69C4E0D86A7B0430D8CDB78070B4C55A", "hex"));
+      }
+
+      // AES-192
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("000102030405060708090A0B0C0D0E0F1011121314151617", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("00112233445566778899AABBCCDDEEFF", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("DDA97CA4864CDFE06EAF70A0EC0D7191", "hex"));
+      }
+
+      // AES-256
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("00112233445566778899AABBCCDDEEFF", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("8EA2B7CA516745BFEAFC49904B496089", "hex"));
+      }
+    });
+
+    it("can encrypt a single block (PasswordLib test vectors)", () => {
+      const aes = new ctx.AES();
+
+      // https://github.com/ircmaxell/quality-checker/blob/63e91ea/tmp/gh_18/PHP-PasswordLib-master/test/Data/Vectors/aes-ecb.test-vectors
+
+      // AES-128 (vector 1-4)
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("6bc1bee22e409f96e93d7e117393172a", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("3ad77bb40d7a3660a89ecaf32466ef97", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("ae2d8a571e03ac9c9eb76fac45af8e51", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("f5d3d58503b9699de785895a96fdbaaf", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("30c81c46a35ce411e5fbc1191a0a52ef", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("43b1cd7f598ece23881b00e3ed030688", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("2b7e151628aed2a6abf7158809cf4f3c", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("f69f2445df4f9b17ad2b417be66c3710", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("7b0c785e27e8ad3f8223207104725dd4", "hex"));
+      }
+
+      // AES-192 (vector 1-4)
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("6bc1bee22e409f96e93d7e117393172a", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("bd334f1d6e45f25ff712a214571fa5cc", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("ae2d8a571e03ac9c9eb76fac45af8e51", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("974104846d0ad3ad7734ecb3ecee4eef", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("30c81c46a35ce411e5fbc1191a0a52ef", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("ef7afd2270e2e60adce0ba2face6444e", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("f69f2445df4f9b17ad2b417be66c3710", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("9a4b41ba738d6c72fb16691603c18e0e", "hex"));
+      }
+
+      // AES-256 (vector 1-4)
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("6bc1bee22e409f96e93d7e117393172a", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("f3eed1bdb5d2a03c064b5a7e3db181f8", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("ae2d8a571e03ac9c9eb76fac45af8e51", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("591ccb10d410ed26dc5ba74a31362870", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("30c81c46a35ce411e5fbc1191a0a52ef", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("b6ed21b99ca6f4f9f153e7b1beafed1d", "hex"));
+      }
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("f69f2445df4f9b17ad2b417be66c3710", "hex");
+        aes.ecb_encrypt(data);
+        expect(data).toEqual(Buffer.from("23304b7a39f9f3ff067d8d8f9e24ecc7", "hex"));
+      }
+    });
+  });
+
+  describe("ecb_decrypt", () => {
+    it("can decrypt a single block (Botan test vectors)", () => {
+      const aes = new ctx.AES();
+
+      // Test vectors from
+      // https://github.com/randombit/botan/blob/2.10.0/src/tests/data/block/aes.vec
+
+      // AES-128
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          16,
+          Buffer.from("000102030405060708090A0B0C0D0E0F", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("69C4E0D86A7B0430D8CDB78070B4C55A", "hex");
+        aes.ecb_decrypt(data);
+        expect(data).toEqual(Buffer.from("00112233445566778899AABBCCDDEEFF", "hex"));
+      }
+
+      // AES-192
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          24,
+          Buffer.from("000102030405060708090A0B0C0D0E0F1011121314151617", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("DDA97CA4864CDFE06EAF70A0EC0D7191", "hex");
+        aes.ecb_decrypt(data);
+        expect(data).toEqual(Buffer.from("00112233445566778899AABBCCDDEEFF", "hex"));
+      }
+
+      // AES-256
+      {
+        const initOk = aes.init(
+          ctx.AES.ECB,
+          32,
+          Buffer.from("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", "hex"),
+          null
+        );
+        expect(initOk).toBeUndefined();
+        const data = Buffer.from("8EA2B7CA516745BFEAFC49904B496089", "hex");
+        aes.ecb_decrypt(data);
+        expect(data).toEqual(Buffer.from("00112233445566778899AABBCCDDEEFF", "hex"));
+      }
+    });
+  });
+});

--- a/version3/js/big.spec.js
+++ b/version3/js/big.spec.js
@@ -1,0 +1,143 @@
+const { randomBytes } = require("crypto");
+
+const { CTX } = require("./ctx");
+
+describe("BIG", () => {
+  const ctx = new CTX("ED25519");
+
+  describe("zero", () => {
+    it("sets value to 0 and returns this", () => {
+      const a = new ctx.BIG(42);
+      expect(a.zero()).toBe(a);
+      expect(a.w.every(word => word === 0)).toEqual(true);
+    });
+  });
+
+  describe("one", () => {
+    it("sets value to 1 and returns this", () => {
+      const a = new ctx.BIG(42);
+      expect(a.one()).toBe(a);
+      expect(a.w.slice(1).every(word => word === 0)).toEqual(true);
+      expect(a.w[0]).toEqual(1);
+    });
+  });
+
+  describe("copy", () => {});
+  describe("hcopy", () => {});
+  describe("rcopy", () => {});
+
+  describe("nbits", () => {
+    it("works", () => {
+      expect(new ctx.BIG(0b000000).nbits()).toEqual(0);
+
+      expect(new ctx.BIG(0b000001).nbits()).toEqual(1);
+      expect(new ctx.BIG(0b000010).nbits()).toEqual(2);
+      expect(new ctx.BIG(0b000100).nbits()).toEqual(3);
+      expect(new ctx.BIG(0b001000).nbits()).toEqual(4);
+      expect(new ctx.BIG(0b010000).nbits()).toEqual(5);
+
+      expect(new ctx.BIG(0b000001).nbits()).toEqual(1);
+      expect(new ctx.BIG(0b000011).nbits()).toEqual(2);
+      expect(new ctx.BIG(0b000111).nbits()).toEqual(3);
+      expect(new ctx.BIG(0b001111).nbits()).toEqual(4);
+      expect(new ctx.BIG(0b011111).nbits()).toEqual(5);
+    });
+  });
+});
+
+describe("BIGStatic", () => {
+  const ctx = new CTX("ED25519");
+
+  it("has corect static values", () => {
+    expect(ctx.BIG.NLEN).toEqual(11);
+    expect(ctx.BIG.DNLEN).toEqual(22);
+  });
+
+  describe("comp", () => {
+    it("works for a == b", () => {
+      const a = new ctx.BIG(5);
+      const b = new ctx.BIG(5);
+      expect(ctx.BIG.comp(a, b)).toEqual(0);
+    });
+
+    it("works for a < b", () => {
+      const a = new ctx.BIG(4);
+      const b = new ctx.BIG(5);
+      expect(ctx.BIG.comp(a, b)).toEqual(-1);
+    });
+
+    it("works for a > b", () => {
+      const a = new ctx.BIG(6);
+      const b = new ctx.BIG(5);
+      expect(ctx.BIG.comp(a, b)).toEqual(1);
+    });
+  });
+
+  describe("randomnum", () => {
+    it("works", () => {
+      const rng = new ctx.RAND();
+      const q = new ctx.BIG(123);
+      const a = ctx.BIG.randomnum(q, rng);
+      expect(a).toBeInstanceOf(ctx.BIG);
+      expect(ctx.BIG.comp(a, new ctx.BIG(123))).toEqual(-1);
+    });
+
+    it("works for different limits", () => {
+      const rng = new ctx.RAND();
+      expect(ctx.BIG.comp(ctx.BIG.randomnum(new ctx.BIG(100), rng), new ctx.BIG(100))).toEqual(-1);
+      expect(ctx.BIG.comp(ctx.BIG.randomnum(new ctx.BIG(10), rng), new ctx.BIG(10))).toEqual(-1);
+      expect(ctx.BIG.comp(ctx.BIG.randomnum(new ctx.BIG(1), rng), new ctx.BIG(1))).toEqual(-1);
+      // the following line will cause an infinite loop
+      // expect(ctx.BIG.comp(ctx.BIG.randomnum(new ctx.BIG(0), rng), new ctx.BIG(0))).toEqual(-1);
+    });
+
+    // A very basic distribution test that only prevents the most horrible bugs
+    it("leads to uniform distribution", () => {
+      const seed = randomBytes(16);
+      const rng = new ctx.RAND();
+      rng.seed(seed.length, seed);
+
+      const q = new ctx.BIG(10); // a 4 bit value
+      const counts = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+      const iterations = 70000;
+      for (let i = 0; i < iterations; ++i) {
+        const a = ctx.BIG.randomnum(q, rng); // a is in [0, 1, 2, ..., 9]
+        const lowWord = a.w[0];
+        counts[lowWord] += 1;
+      }
+      const proportions = counts.map(count => count / counts.reduce((a, b) => a + b, 0));
+      // console.log(proportions);
+      expect(proportions[0]).toBeCloseTo(1 / 10);
+      expect(proportions[1]).toBeCloseTo(1 / 10);
+      expect(proportions[2]).toBeCloseTo(1 / 10);
+      expect(proportions[3]).toBeCloseTo(1 / 10);
+      expect(proportions[4]).toBeCloseTo(1 / 10);
+      expect(proportions[5]).toBeCloseTo(1 / 10);
+      expect(proportions[6]).toBeCloseTo(1 / 10);
+      expect(proportions[7]).toBeCloseTo(1 / 10);
+      expect(proportions[8]).toBeCloseTo(1 / 10);
+      expect(proportions[9]).toBeCloseTo(1 / 10);
+    });
+  });
+
+  describe("new", () => {
+    it("can be constructed with no argument", () => {
+      const a = new ctx.BIG();
+      expect(a).toBeTruthy();
+      expect(a.w.every(word => word === 0)).toEqual(true);
+    });
+
+    it("can be constructed with zero argument", () => {
+      const a = new ctx.BIG(0);
+      expect(a).toBeTruthy();
+      expect(a.w.every(word => word === 0)).toEqual(true);
+    });
+
+    it("can be constructed with non-zero argument", () => {
+      const a = new ctx.BIG(123);
+      expect(a).toBeTruthy();
+      expect(a.w[0]).toEqual(123);
+      expect(a.w.slice(1).every(word => word === 0)).toEqual(true);
+    });
+  });
+});

--- a/version3/js/dbig.spec.js
+++ b/version3/js/dbig.spec.js
@@ -1,0 +1,20 @@
+const { CTX } = require("./ctx");
+
+describe("DBIGStatic", () => {
+  const ctx = new CTX("ED25519");
+
+  describe("new", () => {
+    it("can be constructed with zero argument", () => {
+      const a = new ctx.DBIG(0);
+      expect(a).toBeTruthy();
+      expect(a.w.every(word => word === 0)).toEqual(true);
+    });
+
+    it("can be constructed with non-zero argument", () => {
+      const a = new ctx.DBIG(123);
+      expect(a).toBeTruthy();
+      expect(a.w[0]).toEqual(123);
+      expect(a.w.slice(1).every(word => word === 0)).toEqual(true);
+    });
+  });
+});

--- a/version3/js/ecp.spec.js
+++ b/version3/js/ecp.spec.js
@@ -1,0 +1,113 @@
+const { CTX } = require("./ctx");
+const { makeGeneratorsPF12 } = require("./util.spec");
+
+describe("ECP", () => {
+  const ctx = new CTX("BN254CX");
+  const { g1 } = makeGeneratorsPF12(ctx);
+
+  describe("sum", () => {
+    it("returns the same point when multiplying with infinity", () => {
+      const a = g1.mul(new ctx.BIG(252525));
+      const infinity = new ctx.ECP();
+
+      expect(a.is_infinity()).toEqual(false);
+      expect(infinity.is_infinity()).toEqual(true);
+
+      const sum = new ctx.ECP();
+      sum.copy(a);
+      sum.add(infinity);
+
+      expect(sum.equals(a)).toEqual(true);
+    });
+  });
+
+  describe("mul", () => {
+    it("does not mutate the instance", () => {
+      const original = new ctx.ECP();
+      original.copy(g1);
+
+      const uut = new ctx.ECP();
+      uut.copy(original);
+
+      const product = uut.mul(new ctx.BIG(252525));
+
+      expect(product.equals(original)).toEqual(false);
+      expect(uut.equals(original)).toEqual(true);
+    });
+
+    it("returns infinity when multiplied by zero", () => {
+      const P = g1.mul(new ctx.BIG(112233));
+      expect(P.is_infinity()).toEqual(false);
+      const product = P.mul(new ctx.BIG(0));
+      expect(product.is_infinity()).toEqual(true);
+    });
+  });
+});
+
+describe("ECPStatic", () => {
+  describe("new", () => {
+    const ctx = new CTX("BN254CX");
+    const { g1 } = makeGeneratorsPF12(ctx);
+
+    it("constructs point at infinity by default", () => {
+      const a = new ctx.ECP();
+      expect(a.is_infinity()).toEqual(true);
+    });
+
+    it("can copy other point", () => {
+      const other = g1.mul(new ctx.BIG(11223344));
+      const a = new ctx.ECP(other);
+      expect(a.is_infinity()).toEqual(false);
+      expect(a.equals(other)).toEqual(true);
+    });
+  });
+
+  describe("CURVETYPE", () => {
+    it("Secp256k1 is of type Weierstrass", () => {
+      const ctxSECP256K1 = new CTX("SECP256K1");
+      expect(ctxSECP256K1.ECP.CURVETYPE).toEqual(ctxSECP256K1.ECP.WEIERSTRASS);
+    });
+
+    it("BNCX is of type Weierstrass", () => {
+      const ctxBN254CX = new CTX("BN254CX");
+      expect(ctxBN254CX.ECP.CURVETYPE).toEqual(ctxBN254CX.ECP.WEIERSTRASS);
+    });
+
+    it("Ed25519 is of type Edwards", () => {
+      const ctxED25519 = new CTX("ED25519");
+      expect(ctxED25519.ECP.CURVETYPE).toEqual(ctxED25519.ECP.EDWARDS);
+    });
+
+    it("Curve25519 is of type montgomery", () => {
+      const ctxC25519 = new CTX("C25519");
+      expect(ctxC25519.ECP.CURVETYPE).toEqual(ctxC25519.ECP.MONTGOMERY);
+    });
+  });
+
+  describe("CURVE_PAIRING_TYPE", () => {
+    it("Secp256k1 is not pairing friendly", () => {
+      const ctxSECP256K1 = new CTX("SECP256K1");
+      expect(ctxSECP256K1.ECP.CURVE_PAIRING_TYPE).toEqual(ctxSECP256K1.ECP.NOT);
+    });
+
+    it("Ed25519 is not pairing friendly", () => {
+      const ctxED25519 = new CTX("ED25519");
+      expect(ctxED25519.ECP.CURVE_PAIRING_TYPE).toEqual(ctxED25519.ECP.NOT);
+    });
+
+    it("Curve25519 is not pairing friendly", () => {
+      const ctxC25519 = new CTX("C25519");
+      expect(ctxC25519.ECP.CURVE_PAIRING_TYPE).toEqual(ctxC25519.ECP.NOT);
+    });
+
+    it("BNCX is BN pairing friendly", () => {
+      const ctxBN254CX = new CTX("BN254CX");
+      expect(ctxBN254CX.ECP.CURVE_PAIRING_TYPE).toEqual(ctxBN254CX.ECP.BN);
+    });
+
+    it("BLS383 is BLS pairing friendly", () => {
+      const ctxBLS383 = new CTX("BLS383");
+      expect(ctxBLS383.ECP.CURVE_PAIRING_TYPE).toEqual(ctxBLS383.ECP.BLS);
+    });
+  });
+});

--- a/version3/js/ecp2.spec.js
+++ b/version3/js/ecp2.spec.js
@@ -1,0 +1,21 @@
+const { CTX } = require("./ctx");
+const { makeGeneratorsPF12 } = require("./util.spec");
+
+describe("ECP2Static", () => {
+  const ctx = new CTX("BN254CX");
+  const { g2 } = makeGeneratorsPF12(ctx);
+
+  describe("new", () => {
+    it("constructs point at infinity by default", () => {
+      const a = new ctx.ECP2();
+      expect(a.is_infinity()).toEqual(true);
+    });
+
+    it("can copy other point", () => {
+      const other = g2.mul(new ctx.BIG(11223344));
+      const a = new ctx.ECP2(other);
+      expect(a.is_infinity()).toEqual(false);
+      expect(a.equals(other)).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp.spec.js
+++ b/version3/js/fp.spec.js
@@ -1,0 +1,52 @@
+const { CTX } = require("./ctx");
+
+describe("FP", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("add", () => {
+    it("does component-wise addition", () => {
+      const a = new ctx.FP(10);
+      const b = new ctx.FP(1);
+      const expectedSum = new ctx.FP(11);
+
+      const sum = new ctx.FP(a);
+      sum.add(b);
+      expect(sum.equals(expectedSum)).toEqual(true);
+    });
+  });
+
+  describe("sub", () => {
+    it("does component-wise subtraction", () => {
+      const a = new ctx.FP(10);
+      const b = new ctx.FP(1);
+      const expectedDifference = new ctx.FP(9);
+
+      const difference = new ctx.FP(a);
+      difference.sub(b);
+      expect(difference.equals(expectedDifference)).toEqual(true);
+    });
+  });
+});
+
+describe("FPStatic", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("MODTYPE", () => {
+    it("has no special modtype", () => {
+      expect(ctx.FP.MODTYPE).toEqual(ctx.FP.NOT_SPECIAL);
+    });
+  });
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value and representation with undefined and 0", () => {
+      const a = new ctx.FP();
+      const b = new ctx.FP(0);
+      expect(a.equals(b)).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp12.spec.js
+++ b/version3/js/fp12.spec.js
@@ -1,0 +1,89 @@
+const { CTX } = require("./ctx");
+
+describe("FP12", () => {
+  // add, sub not yet implemented
+  // https://github.com/miracl/amcl/issues/28
+});
+
+describe("FP12Static", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP12();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value with undefined and 0", () => {
+      const a = new ctx.FP12();
+      const b = new ctx.FP12(0);
+      expect(a.equals(b)).toEqual(true);
+    });
+
+    it("can construct from a single number 0", () => {
+      pending("Sparse type not yet working when constructed with single number 0");
+      const x = new ctx.FP12(0);
+      expect(x.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ZERO);
+    });
+
+    it("can construct from a single number 1", () => {
+      const x = new ctx.FP12(1);
+      expect(x.isunity()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ONE);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP12(13);
+      expect(x.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can construct from a single FP4", () => {
+      pending("Not yet working");
+      const x = new ctx.FP12(new ctx.FP4(14));
+      expect(x.a.a.a.equals(new ctx.FP(14))).toEqual(true);
+      expect(x.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP12(new ctx.FP4(13), new ctx.FP4(14), new ctx.FP4(15));
+      const copy = new ctx.FP12(original);
+
+      expect(copy.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(copy.a.a.b.iszilch()).toEqual(true);
+      expect(copy.a.b.a.iszilch()).toEqual(true);
+      expect(copy.a.b.b.iszilch()).toEqual(true);
+      expect(copy.b.a.a.equals(new ctx.FP(14))).toEqual(true);
+      expect(copy.b.a.b.iszilch()).toEqual(true);
+      expect(copy.b.b.a.iszilch()).toEqual(true);
+      expect(copy.b.b.b.iszilch()).toEqual(true);
+      expect(copy.c.a.a.equals(new ctx.FP(15))).toEqual(true);
+      expect(copy.c.a.b.iszilch()).toEqual(true);
+      expect(copy.c.b.a.iszilch()).toEqual(true);
+      expect(copy.c.b.b.iszilch()).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp16.spec.js
+++ b/version3/js/fp16.spec.js
@@ -1,0 +1,174 @@
+const { CTX } = require("./ctx");
+
+describe("FP16", () => {
+  const ctx = new CTX("BLS48");
+
+  describe("add", () => {
+    it("does component-wise addition", () => {
+      const a = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(100, 200), new ctx.FP2(300, 400)),
+          new ctx.FP4(new ctx.FP2(500, 600), new ctx.FP2(700, 800))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(900, 1000), new ctx.FP2(1100, 1200)),
+          new ctx.FP4(new ctx.FP2(1300, 1400), new ctx.FP2(1500, 1600))
+        )
+      );
+      const b = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+          new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(9, 10), new ctx.FP2(11, 12)),
+          new ctx.FP4(new ctx.FP2(13, 14), new ctx.FP2(15, 16))
+        )
+      );
+      const expectedSum = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(101, 202), new ctx.FP2(303, 404)),
+          new ctx.FP4(new ctx.FP2(505, 606), new ctx.FP2(707, 808))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(909, 1010), new ctx.FP2(1111, 1212)),
+          new ctx.FP4(new ctx.FP2(1313, 1414), new ctx.FP2(1515, 1616))
+        )
+      );
+
+      const sum = new ctx.FP16(a);
+      sum.add(b);
+      expect(sum.equals(expectedSum)).toEqual(true);
+    });
+  });
+
+  describe("sub", () => {
+    it("does component-wise subtraction", () => {
+      const a = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(100, 200), new ctx.FP2(300, 400)),
+          new ctx.FP4(new ctx.FP2(500, 600), new ctx.FP2(700, 800))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(900, 1000), new ctx.FP2(1100, 1200)),
+          new ctx.FP4(new ctx.FP2(1300, 1400), new ctx.FP2(1500, 1600))
+        )
+      );
+      const b = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+          new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(9, 10), new ctx.FP2(11, 12)),
+          new ctx.FP4(new ctx.FP2(13, 14), new ctx.FP2(15, 16))
+        )
+      );
+      const expectedDifference = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(99, 198), new ctx.FP2(297, 396)),
+          new ctx.FP4(new ctx.FP2(495, 594), new ctx.FP2(693, 792))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(891, 990), new ctx.FP2(1089, 1188)),
+          new ctx.FP4(new ctx.FP2(1287, 1386), new ctx.FP2(1485, 1584))
+        )
+      );
+
+      const difference = new ctx.FP16(a);
+      difference.sub(b);
+      expect(difference.equals(expectedDifference)).toEqual(true);
+    });
+  });
+});
+
+describe("FP16Static", () => {
+  const ctx = new CTX("BLS48");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP16();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value with undefined and 0", () => {
+      const a = new ctx.FP16();
+      const b = new ctx.FP16(0);
+      const c = new ctx.FP16(0, 0);
+      expect(a.equals(b)).toEqual(true);
+      expect(a.equals(c)).toEqual(true);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP16(13);
+      expect(x.a.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.iszilch()).toEqual(true);
+    });
+
+    it("can construct from multiple numbers", () => {
+      const x = new ctx.FP16(13, 14);
+
+      expect(x.a.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.equals(new ctx.FP(14))).toEqual(true);
+      expect(x.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.iszilch()).toEqual(true);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP16(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+          new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(9, 10), new ctx.FP2(11, 12)),
+          new ctx.FP4(new ctx.FP2(13, 14), new ctx.FP2(15, 16))
+        )
+      );
+      const copy = new ctx.FP16(original);
+
+      expect(copy.a.a.a.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.a.a.a.b.equals(new ctx.FP(2))).toEqual(true);
+      expect(copy.a.a.b.a.equals(new ctx.FP(3))).toEqual(true);
+      expect(copy.a.a.b.b.equals(new ctx.FP(4))).toEqual(true);
+      expect(copy.a.b.a.a.equals(new ctx.FP(5))).toEqual(true);
+      expect(copy.a.b.a.b.equals(new ctx.FP(6))).toEqual(true);
+      expect(copy.a.b.b.a.equals(new ctx.FP(7))).toEqual(true);
+      expect(copy.a.b.b.b.equals(new ctx.FP(8))).toEqual(true);
+      expect(copy.b.a.a.a.equals(new ctx.FP(9))).toEqual(true);
+      expect(copy.b.a.a.b.equals(new ctx.FP(10))).toEqual(true);
+      expect(copy.b.a.b.a.equals(new ctx.FP(11))).toEqual(true);
+      expect(copy.b.a.b.b.equals(new ctx.FP(12))).toEqual(true);
+      expect(copy.b.b.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(copy.b.b.a.b.equals(new ctx.FP(14))).toEqual(true);
+      expect(copy.b.b.b.a.equals(new ctx.FP(15))).toEqual(true);
+      expect(copy.b.b.b.b.equals(new ctx.FP(16))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp2.spec.js
+++ b/version3/js/fp2.spec.js
@@ -1,0 +1,60 @@
+const { CTX } = require("./ctx");
+
+describe("FP2", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("add", () => {
+    it("does component-wise addition", () => {
+      const a = new ctx.FP2(10, 20);
+      const b = new ctx.FP2(1, 2);
+      const expectedSum = new ctx.FP2(11, 22);
+
+      const sum = new ctx.FP2(a);
+      sum.add(b);
+      expect(sum.equals(expectedSum)).toEqual(true);
+    });
+  });
+
+  describe("sub", () => {
+    it("does component-wise subtraction", () => {
+      const a = new ctx.FP2(10, 20);
+      const b = new ctx.FP2(1, 2);
+      const expectedDifference = new ctx.FP2(9, 18);
+
+      const difference = new ctx.FP2(a);
+      difference.sub(b);
+      expect(difference.equals(expectedDifference)).toEqual(true);
+    });
+  });
+});
+
+describe("FP2Static", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP2();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value and representation with undefined and 0", () => {
+      const a = new ctx.FP2();
+      const b = new ctx.FP2(0, 0);
+      expect(a).toEqual(b);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP2(13);
+      expect(x.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.b.iszilch()).toEqual(true);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP2(1, 2);
+      const copy = new ctx.FP2(original);
+
+      expect(copy.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.b.equals(new ctx.FP(2))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp24.spec.js
+++ b/version3/js/fp24.spec.js
@@ -1,0 +1,138 @@
+const { CTX } = require("./ctx");
+
+describe("FP24", () => {
+  // add, sub not yet implemented
+  // https://github.com/miracl/amcl/issues/28
+});
+
+describe("FP24Static", () => {
+  const ctx = new CTX("BLS24");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP24();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value with undefined and 0", () => {
+      const a = new ctx.FP24();
+      const b = new ctx.FP24(0);
+      expect(a.equals(b)).toEqual(true);
+    });
+
+    it("can construct from a single number 0", () => {
+      pending("Sparse type not yet working when constructed with single number 0");
+      const x = new ctx.FP24(0);
+      expect(x.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ZERO);
+    });
+
+    it("can construct from a single number 1", () => {
+      const x = new ctx.FP24(1);
+      expect(x.isunity()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ONE);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP24(13);
+      expect(x.a.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can construct from a single FP8", () => {
+      pending("Not yet working");
+      const x = new ctx.FP24(new ctx.FP8(14));
+      expect(x.a.a.a.a.equals(new ctx.FP(14))).toEqual(true);
+      expect(x.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP24(
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+          new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(9, 10), new ctx.FP2(11, 12)),
+          new ctx.FP4(new ctx.FP2(13, 14), new ctx.FP2(15, 16))
+        ),
+        new ctx.FP8(
+          new ctx.FP4(new ctx.FP2(17, 18), new ctx.FP2(19, 20)),
+          new ctx.FP4(new ctx.FP2(21, 22), new ctx.FP2(23, 24))
+        )
+      );
+      const copy = new ctx.FP24(original);
+
+      expect(copy.a.a.a.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.a.a.a.b.equals(new ctx.FP(2))).toEqual(true);
+      expect(copy.a.a.b.a.equals(new ctx.FP(3))).toEqual(true);
+      expect(copy.a.a.b.b.equals(new ctx.FP(4))).toEqual(true);
+      expect(copy.a.b.a.a.equals(new ctx.FP(5))).toEqual(true);
+      expect(copy.a.b.a.b.equals(new ctx.FP(6))).toEqual(true);
+      expect(copy.a.b.b.a.equals(new ctx.FP(7))).toEqual(true);
+      expect(copy.a.b.b.b.equals(new ctx.FP(8))).toEqual(true);
+      expect(copy.b.a.a.a.equals(new ctx.FP(9))).toEqual(true);
+      expect(copy.b.a.a.b.equals(new ctx.FP(10))).toEqual(true);
+      expect(copy.b.a.b.a.equals(new ctx.FP(11))).toEqual(true);
+      expect(copy.b.a.b.b.equals(new ctx.FP(12))).toEqual(true);
+      expect(copy.b.b.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(copy.b.b.a.b.equals(new ctx.FP(14))).toEqual(true);
+      expect(copy.b.b.b.a.equals(new ctx.FP(15))).toEqual(true);
+      expect(copy.b.b.b.b.equals(new ctx.FP(16))).toEqual(true);
+      expect(copy.c.a.a.a.equals(new ctx.FP(17))).toEqual(true);
+      expect(copy.c.a.a.b.equals(new ctx.FP(18))).toEqual(true);
+      expect(copy.c.a.b.a.equals(new ctx.FP(19))).toEqual(true);
+      expect(copy.c.a.b.b.equals(new ctx.FP(20))).toEqual(true);
+      expect(copy.c.b.a.a.equals(new ctx.FP(21))).toEqual(true);
+      expect(copy.c.b.a.b.equals(new ctx.FP(22))).toEqual(true);
+      expect(copy.c.b.b.a.equals(new ctx.FP(23))).toEqual(true);
+      expect(copy.c.b.b.b.equals(new ctx.FP(24))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp4.spec.js
+++ b/version3/js/fp4.spec.js
@@ -1,0 +1,64 @@
+const { CTX } = require("./ctx");
+
+describe("FP4", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("add", () => {
+    it("does component-wise addition", () => {
+      const a = new ctx.FP4(new ctx.FP2(10, 20), new ctx.FP2(30, 40));
+      const b = new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4));
+      const expectedSum = new ctx.FP4(new ctx.FP2(11, 22), new ctx.FP2(33, 44));
+
+      const sum = new ctx.FP4(a);
+      sum.add(b);
+      expect(sum.equals(expectedSum)).toEqual(true);
+    });
+  });
+
+  describe("sub", () => {
+    it("does component-wise subtraction", () => {
+      const a = new ctx.FP4(new ctx.FP2(10, 20), new ctx.FP2(30, 40));
+      const b = new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4));
+      const expectedDifference = new ctx.FP4(new ctx.FP2(9, 18), new ctx.FP2(27, 36));
+
+      const difference = new ctx.FP4(a);
+      difference.sub(b);
+      expect(difference.equals(expectedDifference)).toEqual(true);
+    });
+  });
+});
+
+describe("FP4Static", () => {
+  const ctx = new CTX("BN254CX");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP4();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value and representation with undefined and 0", () => {
+      const a = new ctx.FP4();
+      const b = new ctx.FP4(new ctx.FP2(), new ctx.FP2());
+      expect(a).toEqual(b);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP4(13);
+      expect(x.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.iszilch()).toEqual(true);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4));
+      const copy = new ctx.FP4(original);
+
+      expect(copy.a.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.a.b.equals(new ctx.FP(2))).toEqual(true);
+      expect(copy.b.a.equals(new ctx.FP(3))).toEqual(true);
+      expect(copy.b.b.equals(new ctx.FP(4))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp48.spec.js
+++ b/version3/js/fp48.spec.js
@@ -1,0 +1,228 @@
+const { CTX } = require("./ctx");
+
+describe("FP48", () => {
+  // add, sub not yet implemented
+  // https://github.com/miracl/amcl/issues/28
+});
+
+describe("FP48Static", () => {
+  const ctx = new CTX("BLS48");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP48();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value with undefined and 0", () => {
+      const a = new ctx.FP48();
+      const b = new ctx.FP48(0);
+      expect(a.equals(b)).toEqual(true);
+    });
+
+    it("can construct from a single number 0", () => {
+      pending("Sparse type not yet working when constructed with single number 0");
+      const x = new ctx.FP48(0);
+      expect(x.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ZERO);
+    });
+
+    it("can construct from a single number 1", () => {
+      const x = new ctx.FP48(1);
+      expect(x.isunity()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.ONE);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP48(13);
+      expect(x.a.a.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can construct from a single FP16", () => {
+      pending("Not yet working");
+      const x = new ctx.FP48(new ctx.FP16(14));
+      expect(x.a.a.a.a.a.equals(new ctx.FP(14))).toEqual(true);
+      expect(x.a.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.a.b.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.a.b.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.a.b.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.a.iszilch()).toEqual(true);
+      expect(x.c.b.b.b.b.iszilch()).toEqual(true);
+      expect(x.stype).toEqual(ctx.FP.SPARSER);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP48(
+        new ctx.FP16(
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+            new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+          ),
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(9, 10), new ctx.FP2(11, 12)),
+            new ctx.FP4(new ctx.FP2(13, 14), new ctx.FP2(15, 16))
+          )
+        ),
+        new ctx.FP16(
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(17, 18), new ctx.FP2(19, 20)),
+            new ctx.FP4(new ctx.FP2(21, 22), new ctx.FP2(23, 24))
+          ),
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(25, 26), new ctx.FP2(27, 28)),
+            new ctx.FP4(new ctx.FP2(29, 30), new ctx.FP2(31, 32))
+          )
+        ),
+        new ctx.FP16(
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(33, 34), new ctx.FP2(35, 36)),
+            new ctx.FP4(new ctx.FP2(37, 38), new ctx.FP2(39, 40))
+          ),
+          new ctx.FP8(
+            new ctx.FP4(new ctx.FP2(41, 42), new ctx.FP2(43, 44)),
+            new ctx.FP4(new ctx.FP2(45, 46), new ctx.FP2(47, 48))
+          )
+        )
+      );
+      const copy = new ctx.FP48(original);
+
+      expect(copy.a.a.a.a.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.a.a.a.a.b.equals(new ctx.FP(2))).toEqual(true);
+      expect(copy.a.a.a.b.a.equals(new ctx.FP(3))).toEqual(true);
+      expect(copy.a.a.a.b.b.equals(new ctx.FP(4))).toEqual(true);
+      expect(copy.a.a.b.a.a.equals(new ctx.FP(5))).toEqual(true);
+      expect(copy.a.a.b.a.b.equals(new ctx.FP(6))).toEqual(true);
+      expect(copy.a.a.b.b.a.equals(new ctx.FP(7))).toEqual(true);
+      expect(copy.a.a.b.b.b.equals(new ctx.FP(8))).toEqual(true);
+      expect(copy.a.b.a.a.a.equals(new ctx.FP(9))).toEqual(true);
+      expect(copy.a.b.a.a.b.equals(new ctx.FP(10))).toEqual(true);
+      expect(copy.a.b.a.b.a.equals(new ctx.FP(11))).toEqual(true);
+      expect(copy.a.b.a.b.b.equals(new ctx.FP(12))).toEqual(true);
+      expect(copy.a.b.b.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(copy.a.b.b.a.b.equals(new ctx.FP(14))).toEqual(true);
+      expect(copy.a.b.b.b.a.equals(new ctx.FP(15))).toEqual(true);
+      expect(copy.a.b.b.b.b.equals(new ctx.FP(16))).toEqual(true);
+      expect(copy.b.a.a.a.a.equals(new ctx.FP(17))).toEqual(true);
+      expect(copy.b.a.a.a.b.equals(new ctx.FP(18))).toEqual(true);
+      expect(copy.b.a.a.b.a.equals(new ctx.FP(19))).toEqual(true);
+      expect(copy.b.a.a.b.b.equals(new ctx.FP(20))).toEqual(true);
+      expect(copy.b.a.b.a.a.equals(new ctx.FP(21))).toEqual(true);
+      expect(copy.b.a.b.a.b.equals(new ctx.FP(22))).toEqual(true);
+      expect(copy.b.a.b.b.a.equals(new ctx.FP(23))).toEqual(true);
+      expect(copy.b.a.b.b.b.equals(new ctx.FP(24))).toEqual(true);
+      expect(copy.b.b.a.a.a.equals(new ctx.FP(25))).toEqual(true);
+      expect(copy.b.b.a.a.b.equals(new ctx.FP(26))).toEqual(true);
+      expect(copy.b.b.a.b.a.equals(new ctx.FP(27))).toEqual(true);
+      expect(copy.b.b.a.b.b.equals(new ctx.FP(28))).toEqual(true);
+      expect(copy.b.b.b.a.a.equals(new ctx.FP(29))).toEqual(true);
+      expect(copy.b.b.b.a.b.equals(new ctx.FP(30))).toEqual(true);
+      expect(copy.b.b.b.b.a.equals(new ctx.FP(31))).toEqual(true);
+      expect(copy.b.b.b.b.b.equals(new ctx.FP(32))).toEqual(true);
+      expect(copy.c.a.a.a.a.equals(new ctx.FP(33))).toEqual(true);
+      expect(copy.c.a.a.a.b.equals(new ctx.FP(34))).toEqual(true);
+      expect(copy.c.a.a.b.a.equals(new ctx.FP(35))).toEqual(true);
+      expect(copy.c.a.a.b.b.equals(new ctx.FP(36))).toEqual(true);
+      expect(copy.c.a.b.a.a.equals(new ctx.FP(37))).toEqual(true);
+      expect(copy.c.a.b.a.b.equals(new ctx.FP(38))).toEqual(true);
+      expect(copy.c.a.b.b.a.equals(new ctx.FP(39))).toEqual(true);
+      expect(copy.c.a.b.b.b.equals(new ctx.FP(40))).toEqual(true);
+      expect(copy.c.b.a.a.a.equals(new ctx.FP(41))).toEqual(true);
+      expect(copy.c.b.a.a.b.equals(new ctx.FP(42))).toEqual(true);
+      expect(copy.c.b.a.b.a.equals(new ctx.FP(43))).toEqual(true);
+      expect(copy.c.b.a.b.b.equals(new ctx.FP(44))).toEqual(true);
+      expect(copy.c.b.b.a.a.equals(new ctx.FP(45))).toEqual(true);
+      expect(copy.c.b.b.a.b.equals(new ctx.FP(46))).toEqual(true);
+      expect(copy.c.b.b.b.a.equals(new ctx.FP(47))).toEqual(true);
+      expect(copy.c.b.b.b.b.equals(new ctx.FP(48))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/fp8.spec.js
+++ b/version3/js/fp8.spec.js
@@ -1,0 +1,93 @@
+const { CTX } = require("./ctx");
+
+describe("FP8", () => {
+  const ctx = new CTX("BLS24");
+
+  describe("add", () => {
+    it("does component-wise addition", () => {
+      const a = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(10, 20), new ctx.FP2(30, 40)),
+        new ctx.FP4(new ctx.FP2(50, 60), new ctx.FP2(70, 80))
+      );
+      const b = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+        new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+      );
+      const expectedSum = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(11, 22), new ctx.FP2(33, 44)),
+        new ctx.FP4(new ctx.FP2(55, 66), new ctx.FP2(77, 88))
+      );
+
+      const sum = new ctx.FP8(a);
+      sum.add(b);
+      expect(sum.equals(expectedSum)).toEqual(true);
+    });
+  });
+
+  describe("sub", () => {
+    it("does component-wise subtraction", () => {
+      const a = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(10, 20), new ctx.FP2(30, 40)),
+        new ctx.FP4(new ctx.FP2(50, 60), new ctx.FP2(70, 80))
+      );
+      const b = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+        new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+      );
+      const expectedDifference = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(9, 18), new ctx.FP2(27, 36)),
+        new ctx.FP4(new ctx.FP2(45, 54), new ctx.FP2(63, 72))
+      );
+
+      const difference = new ctx.FP8(a);
+      difference.sub(b);
+      expect(difference.equals(expectedDifference)).toEqual(true);
+    });
+  });
+});
+
+describe("FP8Static", () => {
+  const ctx = new CTX("BLS24");
+
+  describe("new", () => {
+    it("is zero when constructed without arguments", () => {
+      const a = new ctx.FP8();
+      expect(a.iszilch()).toEqual(true);
+    });
+
+    it("produces equal value and representation with undefined and 0", () => {
+      const a = new ctx.FP8();
+      const b = new ctx.FP8(new ctx.FP4(), new ctx.FP4());
+      expect(a).toEqual(b);
+    });
+
+    it("can construct from a single number", () => {
+      const x = new ctx.FP8(13);
+      expect(x.a.a.a.equals(new ctx.FP(13))).toEqual(true);
+      expect(x.a.a.b.iszilch()).toEqual(true);
+      expect(x.a.b.a.iszilch()).toEqual(true);
+      expect(x.a.b.b.iszilch()).toEqual(true);
+      expect(x.b.a.a.iszilch()).toEqual(true);
+      expect(x.b.a.b.iszilch()).toEqual(true);
+      expect(x.b.b.a.iszilch()).toEqual(true);
+      expect(x.b.b.b.iszilch()).toEqual(true);
+    });
+
+    it("can be copied", () => {
+      const original = new ctx.FP8(
+        new ctx.FP4(new ctx.FP2(1, 2), new ctx.FP2(3, 4)),
+        new ctx.FP4(new ctx.FP2(5, 6), new ctx.FP2(7, 8))
+      );
+      const copy = new ctx.FP8(original);
+
+      expect(copy.a.a.a.equals(new ctx.FP(1))).toEqual(true);
+      expect(copy.a.a.b.equals(new ctx.FP(2))).toEqual(true);
+      expect(copy.a.b.a.equals(new ctx.FP(3))).toEqual(true);
+      expect(copy.a.b.b.equals(new ctx.FP(4))).toEqual(true);
+      expect(copy.b.a.a.equals(new ctx.FP(5))).toEqual(true);
+      expect(copy.b.a.b.equals(new ctx.FP(6))).toEqual(true);
+      expect(copy.b.b.a.equals(new ctx.FP(7))).toEqual(true);
+      expect(copy.b.b.b.equals(new ctx.FP(8))).toEqual(true);
+    });
+  });
+});

--- a/version3/js/package.json
+++ b/version3/js/package.json
@@ -7,10 +7,15 @@
   "author": "The Apache Software Foundation",
   "license": "Apache-2.0",
   "private": true,
+  "jest": {
+    "testPathIgnorePatterns": ["util.spec.js"]
+  },
   "scripts": {
-    "format": "prettier --write --loglevel warn \"./*.js\""
+    "format": "prettier --write --loglevel warn \"./*.js\"",
+    "test": "jest"
   },
   "devDependencies": {
+    "jest": "^24.8.0",
     "prettier": "^1.18.2"
   }
 }

--- a/version3/js/pair.spec.js
+++ b/version3/js/pair.spec.js
@@ -1,0 +1,131 @@
+const { CTX } = require("./ctx");
+const { makeGeneratorsPF12 } = require("./util.spec");
+
+describe("PAIRStatic", () => {
+  const ctx = new CTX("BN254CX");
+  const { g1, g2 } = makeGeneratorsPF12(ctx);
+
+  it("satisfies e(aP, bQ) == e(P,Q)^ab == e(bP, aQ)", () => {
+    const rng = new ctx.RAND();
+    const n = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Order);
+    const a = ctx.BIG.randomnum(n, rng);
+    const b = ctx.BIG.randomnum(n, rng);
+
+    // Use arbitrary points P, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    // e(aP, bQ) == e(bP, aQ)
+    const aP = P.mul(a);
+    const bQ = Q.mul(b);
+    const aQ = Q.mul(a);
+    const bP = P.mul(b);
+    const eaPbQ = ctx.PAIR.fexp(ctx.PAIR.ate(bQ, aP));
+    const ebPaQ = ctx.PAIR.fexp(ctx.PAIR.ate(aQ, bP));
+    expect(eaPbQ).toEqual(ebPaQ);
+
+    // e(aP, bQ) == e(P,Q)^ab
+    const ePQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, P));
+    const ePGab = new ctx.FP12(ePQ).pow(a).pow(b);
+    expect(eaPbQ).toEqual(ePGab);
+  });
+
+  it("satisfies e(P+R,Q) == e(P,Q)*e(R,Q)", () => {
+    // Use arbitrary points P, R, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = g1.mul(new ctx.BIG(42));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, PR));
+    const ePQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, P));
+    const eRQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP12(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P+0,Q) == e(P,Q)*e(0,Q)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, PR));
+    const ePQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, P));
+    const eRQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP12(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+R) == e(P,Q)*e(P,R)", () => {
+    // Use arbitrary points P, Q, R. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = g2.mul(new ctx.BIG(42));
+
+    const QR = new ctx.ECP2();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR.fexp(ctx.PAIR.ate(QR, P));
+    const ePQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, P));
+    const ePR = ctx.PAIR.fexp(ctx.PAIR.ate(R, P));
+
+    const ePQePR = new ctx.FP12(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+0) == e(P,Q)*e(P,0)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = new ctx.ECP2();
+
+    const QR = new ctx.ECP2();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR.fexp(ctx.PAIR.ate(QR, P));
+    const ePQ = ctx.PAIR.fexp(ctx.PAIR.ate(Q, P));
+    const ePR = ctx.PAIR.fexp(ctx.PAIR.ate(R, P));
+
+    const ePQePR = new ctx.FP12(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,0) == 1", () => {
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = new ctx.ECP2();
+    expect(ctx.PAIR.fexp(ctx.PAIR.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,Q) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+    expect(ctx.PAIR.fexp(ctx.PAIR.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,0) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = new ctx.ECP2();
+    expect(ctx.PAIR.fexp(ctx.PAIR.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(g1, g2) != 1", () => {
+    const eg1g2 = ctx.PAIR.fexp(ctx.PAIR.ate(g2, g1));
+    expect(eg1g2.isunity()).toEqual(false);
+  });
+});

--- a/version3/js/pair192.spec.js
+++ b/version3/js/pair192.spec.js
@@ -1,0 +1,131 @@
+const { CTX } = require("./ctx");
+const { makeGeneratorsPF3 } = require("./util.spec");
+
+describe("PAIR192Static", () => {
+  const ctx = new CTX("BLS24");
+  const { g1, g2 } = makeGeneratorsPF3(ctx);
+
+  it("satisfies e(aP, bQ) == e(P,Q)^ab == e(bP, aQ)", () => {
+    const rng = new ctx.RAND();
+    const n = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Order);
+    const a = ctx.BIG.randomnum(n, rng);
+    const b = ctx.BIG.randomnum(n, rng);
+
+    // Use arbitrary points P, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    // e(aP, bQ) == e(bP, aQ)
+    const aP = P.mul(a);
+    const bQ = Q.mul(b);
+    const aQ = Q.mul(a);
+    const bP = P.mul(b);
+    const eaPbQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(bQ, aP));
+    const ebPaQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(aQ, bP));
+    expect(eaPbQ).toEqual(ebPaQ);
+
+    // e(aP, bQ) == e(P,Q)^ab
+    const ePQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P));
+    const ePGab = new ctx.FP24(ePQ).pow(a).pow(b);
+    expect(eaPbQ).toEqual(ePGab);
+  });
+
+  it("satisfies e(P+R,Q) == e(P,Q)*e(R,Q)", () => {
+    // Use arbitrary points P, R, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = g1.mul(new ctx.BIG(42));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, PR));
+    const ePQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P));
+    const eRQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP24(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P+0,Q) == e(P,Q)*e(0,Q)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, PR));
+    const ePQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P));
+    const eRQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP24(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+R) == e(P,Q)*e(P,R)", () => {
+    // Use arbitrary points P, Q, R. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = g2.mul(new ctx.BIG(42));
+
+    const QR = new ctx.ECP4();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR192.fexp(ctx.PAIR192.ate(QR, P));
+    const ePQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P));
+    const ePR = ctx.PAIR192.fexp(ctx.PAIR192.ate(R, P));
+
+    const ePQePR = new ctx.FP24(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+0) == e(P,Q)*e(P,0)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = new ctx.ECP4();
+
+    const QR = new ctx.ECP4();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR192.fexp(ctx.PAIR192.ate(QR, P));
+    const ePQ = ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P));
+    const ePR = ctx.PAIR192.fexp(ctx.PAIR192.ate(R, P));
+
+    const ePQePR = new ctx.FP24(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,0) == 1", () => {
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = new ctx.ECP4();
+    expect(ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,Q) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+    expect(ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,0) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = new ctx.ECP4();
+    expect(ctx.PAIR192.fexp(ctx.PAIR192.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(g1, g2) != 1", () => {
+    const eg1g2 = ctx.PAIR192.fexp(ctx.PAIR192.ate(g2, g1));
+    expect(eg1g2.isunity()).toEqual(false);
+  });
+});

--- a/version3/js/pair256.spec.js
+++ b/version3/js/pair256.spec.js
@@ -1,0 +1,131 @@
+const { CTX } = require("./ctx");
+const { makeGeneratorsPF4 } = require("./util.spec");
+
+describe("PAIR256Static", () => {
+  const ctx = new CTX("BLS48");
+  const { g1, g2 } = makeGeneratorsPF4(ctx);
+
+  it("satisfies e(aP, bQ) == e(P,Q)^ab == e(bP, aQ)", () => {
+    const rng = new ctx.RAND();
+    const n = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Order);
+    const a = ctx.BIG.randomnum(n, rng);
+    const b = ctx.BIG.randomnum(n, rng);
+
+    // Use arbitrary points P, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    // e(aP, bQ) == e(bP, aQ)
+    const aP = P.mul(a);
+    const bQ = Q.mul(b);
+    const aQ = Q.mul(a);
+    const bP = P.mul(b);
+    const eaPbQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(bQ, aP));
+    const ebPaQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(aQ, bP));
+    expect(eaPbQ).toEqual(ebPaQ);
+
+    // e(aP, bQ) == e(P,Q)^ab
+    const ePQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P));
+    const ePGab = new ctx.FP48(ePQ).pow(a).pow(b);
+    expect(eaPbQ).toEqual(ePGab);
+  });
+
+  it("satisfies e(P+R,Q) == e(P,Q)*e(R,Q)", () => {
+    // Use arbitrary points P, R, Q. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = g1.mul(new ctx.BIG(42));
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, PR));
+    const ePQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P));
+    const eRQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP48(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P+0,Q) == e(P,Q)*e(0,Q)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const R = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+
+    const PR = new ctx.ECP();
+    PR.copy(P);
+    PR.add(R);
+
+    const ePRQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, PR));
+    const ePQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P));
+    const eRQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, R));
+
+    const ePQeRQ = new ctx.FP48(ePQ); // the product e(P,Q)*e(R,Q)
+    ePQeRQ.mul(eRQ);
+    expect(ePRQ.equals(ePQeRQ)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+R) == e(P,Q)*e(P,R)", () => {
+    // Use arbitrary points P, Q, R. Must hold for all.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = g2.mul(new ctx.BIG(42));
+
+    const QR = new ctx.ECP8();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR256.fexp(ctx.PAIR256.ate(QR, P));
+    const ePQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P));
+    const ePR = ctx.PAIR256.fexp(ctx.PAIR256.ate(R, P));
+
+    const ePQePR = new ctx.FP48(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,Q+0) == e(P,Q)*e(P,0)", () => {
+    // Use arbitrary points P, Q and R=0.
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = g2.mul(new ctx.BIG(8));
+    const R = new ctx.ECP8();
+
+    const QR = new ctx.ECP8();
+    QR.copy(Q);
+    QR.add(R);
+
+    const ePQR = ctx.PAIR256.fexp(ctx.PAIR256.ate(QR, P));
+    const ePQ = ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P));
+    const ePR = ctx.PAIR256.fexp(ctx.PAIR256.ate(R, P));
+
+    const ePQePR = new ctx.FP48(ePQ); // the product e(P,Q)*e(P,R)
+    ePQePR.mul(ePR);
+    expect(ePQR.equals(ePQePR)).toEqual(true);
+  });
+
+  it("satisfies e(P,0) == 1", () => {
+    const P = g1.mul(new ctx.BIG(5));
+    const Q = new ctx.ECP8();
+    expect(ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,Q) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = g2.mul(new ctx.BIG(8));
+    expect(ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(0,0) == 1", () => {
+    const P = new ctx.ECP();
+    const Q = new ctx.ECP8();
+    expect(ctx.PAIR256.fexp(ctx.PAIR256.ate(Q, P)).isunity()).toEqual(true);
+  });
+
+  it("satisfies e(g1, g2) != 1", () => {
+    const eg1g2 = ctx.PAIR256.fexp(ctx.PAIR256.ate(g2, g1));
+    expect(eg1g2.isunity()).toEqual(false);
+  });
+});

--- a/version3/js/rand.spec.js
+++ b/version3/js/rand.spec.js
@@ -1,0 +1,62 @@
+const { CTX } = require("./ctx");
+
+describe("RAND", () => {
+  const ctx = new CTX();
+
+  it("can be seeded", () => {
+    const rng = new ctx.RAND();
+    expect(rng).toBeTruthy();
+    const entropy = new Uint8Array([0x00, 0x22, 0x44, 0x66, 0x88, 0xaa]);
+    rng.seed(entropy.length, entropy);
+  });
+
+  it("can get bytes", () => {
+    const rng = new ctx.RAND();
+    const entropy = new Uint8Array([0x00, 0x22, 0x44, 0x66, 0x88, 0xaa]);
+    rng.seed(entropy.length, entropy);
+    const results = new Set();
+    for (let i = 0; i < 500; ++i) {
+      const result = rng.getByte();
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(255);
+      results.add(result);
+    }
+    // a very bad entropy test that just prevents us from the most horrible failures
+    expect(results.size).toBeGreaterThanOrEqual(200);
+  });
+
+  it("produces non-constant values", () => {
+    const rng = new ctx.RAND();
+    const entropy = new Uint8Array([0x00, 0x22, 0x44, 0x66, 0x88, 0xaa]);
+    rng.seed(entropy.length, entropy);
+    const values = [rng.getByte(), rng.getByte(), rng.getByte()];
+    expect(values[0]).not.toEqual(values[1]);
+    expect(values[1]).not.toEqual(values[2]);
+    expect(values[2]).not.toEqual(values[0]);
+  });
+
+  it("is deterministic", () => {
+    const rng1 = new ctx.RAND();
+    const entropy1 = new Uint8Array([0x00, 0x11, 0x22]);
+    rng1.seed(entropy1.length, entropy1);
+
+    const rng2 = new ctx.RAND();
+    const entropy2 = new Uint8Array([0x00, 0x11, 0x22]);
+    rng2.seed(entropy2.length, entropy2);
+
+    expect(rng1.getByte()).toEqual(rng2.getByte());
+    expect(rng1.getByte()).toEqual(rng2.getByte());
+    expect(rng1.getByte()).toEqual(rng2.getByte());
+  });
+});
+
+describe("RANDStatic", () => {
+  const ctx = new CTX();
+
+  describe("new", () => {
+    it("can be constructed", () => {
+      const rng = new ctx.RAND();
+      expect(rng).toBeTruthy();
+    });
+  });
+});

--- a/version3/js/uint64.spec.js
+++ b/version3/js/uint64.spec.js
@@ -1,0 +1,90 @@
+const { CTX } = require("./ctx");
+
+describe("UInt64", () => {
+  const ctx = new CTX("ED25519");
+
+  describe("add", () => {
+    it("can add", () => {
+      // only bot
+      {
+        const a = new ctx.UInt64(0, 1);
+        a.add(new ctx.UInt64(0, 2));
+        expect(a.top).toEqual(0);
+        expect(a.bot).toEqual(3);
+      }
+      // only top
+      {
+        const a = new ctx.UInt64(1, 0);
+        a.add(new ctx.UInt64(2, 0));
+        expect(a.top).toEqual(3);
+        expect(a.bot).toEqual(0);
+      }
+      // top, bot
+      {
+        const a = new ctx.UInt64(1, 5);
+        a.add(new ctx.UInt64(2, 4));
+        expect(a.top).toEqual(3);
+        expect(a.bot).toEqual(9);
+      }
+      // overflow in bot
+      {
+        const uint32Max = 2 ** 32 - 1;
+        const a = new ctx.UInt64(0, uint32Max);
+        a.add(new ctx.UInt64(0, 1));
+        expect(a.top).toEqual(1);
+        expect(a.bot).toEqual(0);
+      }
+    });
+  });
+
+  describe("copy", () => {
+    it("can copy", () => {
+      const a = new ctx.UInt64(1, 2);
+      const b = a.copy();
+      expect(b.top).toEqual(1);
+      expect(b.bot).toEqual(2);
+    });
+  });
+
+  describe("shlb", () => {
+    it("can shift left 8 bit", () => {
+      {
+        const a = new ctx.UInt64(0, 1);
+        a.shlb();
+        expect(a.top).toEqual(0);
+        expect(a.bot).toEqual(1 << 8);
+      }
+      {
+        const a = new ctx.UInt64(1, 0);
+        a.shlb();
+        expect(a.top).toEqual(1 << 8);
+        expect(a.bot).toEqual(0);
+      }
+      {
+        const a = new ctx.UInt64(0x00000000, 0xffffffff);
+        a.shlb();
+        expect(a.top).toEqual(0x000000ff << 0);
+        expect(a.bot).toEqual(0xffffff00 << 0);
+      }
+      {
+        const a = new ctx.UInt64(0x000000aa, 0xbbccddee);
+        a.shlb();
+        expect(a.top).toEqual(0x0000aabb << 0);
+        expect(a.bot).toEqual(0xccddee00 << 0);
+      }
+    });
+  });
+});
+
+describe("UInt64Static", () => {
+  const ctx = new CTX("ED25519");
+
+  describe("new", () => {
+    it("can be constructed", () => {
+      const a = new ctx.UInt64(17, 4);
+      expect(a).toBeTruthy();
+      expect(a.top).toEqual(17);
+      expect(a.bot).toEqual(4);
+    });
+  });
+});

--- a/version3/js/util.spec.js
+++ b/version3/js/util.spec.js
@@ -1,0 +1,130 @@
+function makeGeneratorsPF12(ctx) {
+  const g1 = new ctx.ECP();
+  const g1x = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gx);
+
+  if (ctx.ECP.CURVETYPE !== ctx.ECP.MONTGOMERY) {
+    const g1y = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gy);
+    g1.setxy(g1x, g1y);
+  } else {
+    g1.setx(g1x);
+  }
+
+  // Get generator g2 for G2
+  const [xa, xb] = [new ctx.FP(), new ctx.FP()];
+  xa.rcopy(ctx.ROM_CURVE.CURVE_Pxa);
+  xb.rcopy(ctx.ROM_CURVE.CURVE_Pxb);
+  const g2x = new ctx.FP2(xa, xb);
+
+  const [ya, yb] = [new ctx.FP(), new ctx.FP()];
+  ya.rcopy(ctx.ROM_CURVE.CURVE_Pya);
+  yb.rcopy(ctx.ROM_CURVE.CURVE_Pyb);
+  const g2y = new ctx.FP2(ya, yb);
+
+  const g2 = new ctx.ECP2();
+  g2.setxy(g2x, g2y);
+
+  return { g1, g2 };
+}
+
+function makeGeneratorsPF3(ctx) {
+  const g1 = new ctx.ECP();
+  const g1x = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gx);
+
+  if (ctx.ECP.CURVETYPE !== ctx.ECP.MONTGOMERY) {
+    const g1y = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gy);
+    g1.setxy(g1x, g1y);
+  } else {
+    g1.setx(g1x);
+  }
+
+  // Get generator g2 for G2
+  const [xaa, xab, xba, xbb] = [new ctx.FP(), new ctx.FP(), new ctx.FP(), new ctx.FP()];
+  xaa.rcopy(ctx.ROM_CURVE.CURVE_Pxaa);
+  xab.rcopy(ctx.ROM_CURVE.CURVE_Pxab);
+  xba.rcopy(ctx.ROM_CURVE.CURVE_Pxba);
+  xbb.rcopy(ctx.ROM_CURVE.CURVE_Pxbb);
+  const g2x = new ctx.FP4(new ctx.FP2(xaa, xab), new ctx.FP2(xba, xbb));
+
+  const [yaa, yab, yba, ybb] = [new ctx.FP(), new ctx.FP(), new ctx.FP(), new ctx.FP()];
+  yaa.rcopy(ctx.ROM_CURVE.CURVE_Pyaa);
+  yab.rcopy(ctx.ROM_CURVE.CURVE_Pyab);
+  yba.rcopy(ctx.ROM_CURVE.CURVE_Pyba);
+  ybb.rcopy(ctx.ROM_CURVE.CURVE_Pybb);
+  const g2y = new ctx.FP4(new ctx.FP2(yaa, yab), new ctx.FP2(yba, ybb));
+
+  const g2 = new ctx.ECP4();
+  g2.setxy(g2x, g2y);
+
+  return { g1, g2 };
+}
+
+function makeGeneratorsPF4(ctx) {
+  const g1 = new ctx.ECP();
+  const g1x = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gx);
+
+  if (ctx.ECP.CURVETYPE !== ctx.ECP.MONTGOMERY) {
+    const g1y = new ctx.BIG().rcopy(ctx.ROM_CURVE.CURVE_Gy);
+    g1.setxy(g1x, g1y);
+  } else {
+    g1.setx(g1x);
+  }
+
+  // Get generator g2 for G2
+  const [xaaa, xaab, xaba, xabb, xbaa, xbab, xbba, xbbb] = [
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+  ];
+  xaaa.rcopy(ctx.ROM_CURVE.CURVE_Pxaaa);
+  xaab.rcopy(ctx.ROM_CURVE.CURVE_Pxaab);
+  xaba.rcopy(ctx.ROM_CURVE.CURVE_Pxaba);
+  xabb.rcopy(ctx.ROM_CURVE.CURVE_Pxabb);
+  xbaa.rcopy(ctx.ROM_CURVE.CURVE_Pxbaa);
+  xbab.rcopy(ctx.ROM_CURVE.CURVE_Pxbab);
+  xbba.rcopy(ctx.ROM_CURVE.CURVE_Pxbba);
+  xbbb.rcopy(ctx.ROM_CURVE.CURVE_Pxbbb);
+  const g2x = new ctx.FP8(
+    new ctx.FP4(new ctx.FP2(xaaa, xaab), new ctx.FP2(xaba, xabb)),
+    new ctx.FP4(new ctx.FP2(xbaa, xbab), new ctx.FP2(xbba, xbbb))
+  );
+
+  const [yaaa, yaab, yaba, yabb, ybaa, ybab, ybba, ybbb] = [
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+    new ctx.FP(),
+  ];
+  yaaa.rcopy(ctx.ROM_CURVE.CURVE_Pyaaa);
+  yaab.rcopy(ctx.ROM_CURVE.CURVE_Pyaab);
+  yaba.rcopy(ctx.ROM_CURVE.CURVE_Pyaba);
+  yabb.rcopy(ctx.ROM_CURVE.CURVE_Pyabb);
+  ybaa.rcopy(ctx.ROM_CURVE.CURVE_Pybaa);
+  ybab.rcopy(ctx.ROM_CURVE.CURVE_Pybab);
+  ybba.rcopy(ctx.ROM_CURVE.CURVE_Pybba);
+  ybbb.rcopy(ctx.ROM_CURVE.CURVE_Pybbb);
+  const g2y = new ctx.FP8(
+    new ctx.FP4(new ctx.FP2(yaaa, yaab), new ctx.FP2(yaba, yabb)),
+    new ctx.FP4(new ctx.FP2(ybaa, ybab), new ctx.FP2(ybba, ybbb))
+  );
+
+  const g2 = new ctx.ECP8();
+  g2.setxy(g2x, g2y);
+
+  return { g1, g2 };
+}
+
+// CommonJS module exports
+if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
+  module.exports.makeGeneratorsPF12 = makeGeneratorsPF12;
+  module.exports.makeGeneratorsPF3 = makeGeneratorsPF3;
+  module.exports.makeGeneratorsPF4 = makeGeneratorsPF4;
+}


### PR DESCRIPTION
This is a set of unittests I developed over the last weeks. It is far from complete, but includes tests for all the changes we talked about recently. Those tests are configured to run in the CI.

To run them manually, just do

```
cd version3/js
yarn install
yarn test
```

The pair192 and pair256 tests take quire long, so the whole suite runs about 10 minutes. Should not be an issue in the CI. During development, you can filter the tests you run, e.g.

```
yarn test "fp*"
```