### PR TITLE
Use consistent constructors for FP12, FP24, FP48

### DIFF
--- a/version3/js/fp12.js
+++ b/version3/js/fp12.js
@@ -32,25 +32,20 @@ var FP12 = function(ctx) {
       this.b = new ctx.FP4(d.b);
       this.c = new ctx.FP4(d.c);
       this.stype = ctx.FP.DENSE;
-    } else if (typeof d !== "undefined" && typeof e !== "undefined" && typeof f !== "undefined") {
-      // all 3 components set to (can be anything that the FP4 constructor supports)
+    } else if (typeof e === "undefined" && typeof f === "undefined") {
+      // 0-1 components set
+      this.a = new ctx.FP4(d);
+      this.b = new ctx.FP4(0);
+      this.c = new ctx.FP4(0);
+      if (this.a.iszilch()) this.stype = ctx.FP.ZERO;
+      else if (this.a.isunity()) this.stype = ctx.FP.ONE;
+      else this.stype = ctx.FP.SPARSER;
+    } else {
+      // all 3 components set
       this.a = new ctx.FP4(d);
       this.b = new ctx.FP4(e);
       this.c = new ctx.FP4(f);
       this.stype = ctx.FP.DENSE;
-    } else if (typeof d === "number") {
-      // first component is number
-      this.a = new ctx.FP4(d);
-      this.b = new ctx.FP4(0);
-      this.c = new ctx.FP4(0);
-      if (d == 1) this.stype = ctx.FP.ONE;
-      else this.stype = ctx.FP.SPARSER;
-    } else {
-      // other cases, including `new ctx.FP12()` fall back to zero
-      this.a = new ctx.FP4(0);
-      this.b = new ctx.FP4(0);
-      this.c = new ctx.FP4(0);
-      this.stype = ctx.FP.ZERO;
     }
   };
 

--- a/version3/js/fp12.spec.js
+++ b/version3/js/fp12.spec.js
@@ -21,7 +21,6 @@ describe("FP12Static", () => {
     });
 
     it("can construct from a single number 0", () => {
-      pending("Sparse type not yet working when constructed with single number 0");
       const x = new ctx.FP12(0);
       expect(x.iszilch()).toEqual(true);
       expect(x.stype).toEqual(ctx.FP.ZERO);
@@ -51,7 +50,6 @@ describe("FP12Static", () => {
     });
 
     it("can construct from a single FP4", () => {
-      pending("Not yet working");
       const x = new ctx.FP12(new ctx.FP4(14));
       expect(x.a.a.a.equals(new ctx.FP(14))).toEqual(true);
       expect(x.a.a.b.iszilch()).toEqual(true);

--- a/version3/js/fp24.js
+++ b/version3/js/fp24.js
@@ -26,22 +26,25 @@ var FP24 = function(ctx) {
 
   /* general purpose constructor */
   var FP24 = function(d, e, f) {
-    if (!isNaN(d)) {
+    if (d instanceof FP24) {
+      // ignore e, d, which are assumed be undefined in this case
+      this.a = new ctx.FP8(d.a);
+      this.b = new ctx.FP8(d.b);
+      this.c = new ctx.FP8(d.c);
+      this.stype = ctx.FP.DENSE;
+    } else if (typeof e === "undefined" && typeof f === "undefined") {
+      // 0-1 components set
       this.a = new ctx.FP8(d);
       this.b = new ctx.FP8(0);
       this.c = new ctx.FP8(0);
-      if (d == 1) this.stype = ctx.FP.ONE;
+      if (this.a.iszilch()) this.stype = ctx.FP.ZERO;
+      else if (this.a.isunity()) this.stype = ctx.FP.ONE;
       else this.stype = ctx.FP.SPARSER;
     } else {
-      if (d instanceof FP24) {
-        this.a = new ctx.FP8(d.a);
-        this.b = new ctx.FP8(d.b);
-        this.c = new ctx.FP8(d.c);
-      } else {
-        this.a = new ctx.FP8(d);
-        this.b = new ctx.FP8(e);
-        this.c = new ctx.FP8(f);
-      }
+      // all 3 components set
+      this.a = new ctx.FP8(d);
+      this.b = new ctx.FP8(e);
+      this.c = new ctx.FP8(f);
       this.stype = ctx.FP.DENSE;
     }
   };

--- a/version3/js/fp24.spec.js
+++ b/version3/js/fp24.spec.js
@@ -21,7 +21,6 @@ describe("FP24Static", () => {
     });
 
     it("can construct from a single number 0", () => {
-      pending("Sparse type not yet working when constructed with single number 0");
       const x = new ctx.FP24(0);
       expect(x.iszilch()).toEqual(true);
       expect(x.stype).toEqual(ctx.FP.ZERO);
@@ -63,7 +62,6 @@ describe("FP24Static", () => {
     });
 
     it("can construct from a single FP8", () => {
-      pending("Not yet working");
       const x = new ctx.FP24(new ctx.FP8(14));
       expect(x.a.a.a.a.equals(new ctx.FP(14))).toEqual(true);
       expect(x.a.a.a.b.iszilch()).toEqual(true);

--- a/version3/js/fp48.js
+++ b/version3/js/fp48.js
@@ -26,22 +26,25 @@ var FP48 = function(ctx) {
 
   /* general purpose constructor */
   var FP48 = function(d, e, f) {
-    if (!isNaN(d)) {
+    if (d instanceof FP48) {
+      // ignore e, d, which are assumed be undefined in this case
+      this.a = new ctx.FP16(d.a);
+      this.b = new ctx.FP16(d.b);
+      this.c = new ctx.FP16(d.c);
+      this.stype = ctx.FP.DENSE;
+    } else if (typeof e === "undefined" && typeof f === "undefined") {
+      // 0-1 components set
       this.a = new ctx.FP16(d);
       this.b = new ctx.FP16(0);
       this.c = new ctx.FP16(0);
-      if (d == 1) this.stype = ctx.FP.ONE;
+      if (this.a.iszilch()) this.stype = ctx.FP.ZERO;
+      else if (this.a.isunity()) this.stype = ctx.FP.ONE;
       else this.stype = ctx.FP.SPARSER;
     } else {
-      if (d instanceof FP48) {
-        this.a = new ctx.FP16(d.a);
-        this.b = new ctx.FP16(d.b);
-        this.c = new ctx.FP16(d.c);
-      } else {
-        this.a = new ctx.FP16(d);
-        this.b = new ctx.FP16(e);
-        this.c = new ctx.FP16(f);
-      }
+      // all 3 components set
+      this.a = new ctx.FP16(d);
+      this.b = new ctx.FP16(e);
+      this.c = new ctx.FP16(f);
       this.stype = ctx.FP.DENSE;
     }
   };

--- a/version3/js/fp48.spec.js
+++ b/version3/js/fp48.spec.js
@@ -21,7 +21,6 @@ describe("FP48Static", () => {
     });
 
     it("can construct from a single number 0", () => {
-      pending("Sparse type not yet working when constructed with single number 0");
       const x = new ctx.FP48(0);
       expect(x.iszilch()).toEqual(true);
       expect(x.stype).toEqual(ctx.FP.ZERO);
@@ -87,7 +86,6 @@ describe("FP48Static", () => {
     });
 
     it("can construct from a single FP16", () => {
-      pending("Not yet working");
       const x = new ctx.FP48(new ctx.FP16(14));
       expect(x.a.a.a.a.a.equals(new ctx.FP(14))).toEqual(true);
       expect(x.a.a.a.a.b.iszilch()).toEqual(true);


### PR DESCRIPTION
1. Unifies constructors of those 3 similar types
2. Supports all 5 constructors analogue to Java: copy, component-wise, single component, single number, default
3. Reduces FP12 constructor to 3 code blocks
4. Supports sparse types ZERO, ONE, SPARSER for single component, single number, default