### PR TITLE
Check return code in shell commands of config scripts

### DIFF
--- a/version3/c/config16.py
+++ b/version3/c/config16.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,47 +45,47 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ff_"+tff+".c"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.c "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.c "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".c"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.c "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.c "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -96,8 +100,8 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=6
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
-	os.system(copytext+" config_curve.h "+fnameh)
+	fnameh="config_curve_"+tc+".h"
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -113,32 +117,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="fp_"+tf+".c"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.c "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.c "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.c "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.c "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -146,13 +150,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".c"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.c "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.c "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -160,99 +164,99 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.c "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.c "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".c"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.c "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.c "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="fp12_"+tf+".c"
 		fnameh="fp12_"+tf+".h"
 
-		os.system(copytext+" fp12.c "+fnamec)
-		os.system(copytext+" fp12.h "+fnameh)
+		run_in_shell(copytext+" fp12.c "+fnamec)
+		run_in_shell(copytext+" fp12.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="ecp2_"+tc+".c"
 		fnameh="ecp2_"+tc+".h"
 
-		os.system(copytext+" ecp2.c "+fnamec)
-		os.system(copytext+" ecp2.h "+fnameh)
+		run_in_shell(copytext+" ecp2.c "+fnamec)
+		run_in_shell(copytext+" ecp2.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="pair_"+tc+".c"
 		fnameh="pair_"+tc+".h"
 
-		os.system(copytext+" pair.c "+fnamec)
-		os.system(copytext+" pair.h "+fnameh)
+		run_in_shell(copytext+" pair.c "+fnamec)
+		run_in_shell(copytext+" pair.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="mpin_"+tc+".c"
 		fnameh="mpin_"+tc+".h"
 
-		os.system(copytext+" mpin.c "+fnamec)
-		os.system(copytext+" mpin.h "+fnameh)
+		run_in_shell(copytext+" mpin.c "+fnamec)
+		run_in_shell(copytext+" mpin.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="bls_"+tc+".c"
 		fnameh="bls_"+tc+".h"
 
-		os.system(copytext+" bls.c "+fnamec)
-		os.system(copytext+" bls.h "+fnameh)
+		run_in_shell(copytext+" bls.c "+fnamec)
+		run_in_shell(copytext+" bls.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 replace("arch.h","@WL@","16")
 print("Elliptic Curves")
@@ -335,49 +339,49 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp12.*")
-os.system(deltext+" ecp2.*")
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
 # create library
-os.system("gcc -O3 -std=c99 -c randapi.c")
+run_in_shell("gcc -O3 -std=c99 -c randapi.c")
 if curve_selected :
-	os.system("gcc -O3 -std=c99 -c ecdh_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c ecdh_support.c")
 if rsa_selected :
-	os.system("gcc -O3 -std=c99 -c rsa_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c rsa_support.c")
 if pfcurve_selected :
-	os.system("gcc -O3 -std=c99 -c pbc_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c pbc_support.c")
 
-os.system("gcc -O3 -std=c99 -c hash.c")
-os.system("gcc -O3 -std=c99 -c rand.c")
-os.system("gcc -O3 -std=c99 -c oct.c")
-os.system("gcc -O3 -std=c99 -c aes.c")
-os.system("gcc -O3 -std=c99 -c gcm.c")
-os.system("gcc -O3 -std=c99 -c newhope.c")
+run_in_shell("gcc -O3 -std=c99 -c hash.c")
+run_in_shell("gcc -O3 -std=c99 -c rand.c")
+run_in_shell("gcc -O3 -std=c99 -c oct.c")
+run_in_shell("gcc -O3 -std=c99 -c aes.c")
+run_in_shell("gcc -O3 -std=c99 -c gcm.c")
+run_in_shell("gcc -O3 -std=c99 -c newhope.c")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
+	run_in_shell("ar rc amcl.a *.o")
 
-os.system(deltext+" *.o")
+run_in_shell(deltext+" *.o")
 
 
 #print("Your section was ")

--- a/version3/c/config16.py
+++ b/version3/c/config16.py
@@ -36,7 +36,7 @@ def rsaset(tb,tff,nb,base,ml) :
 	os.system(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
-	replace(fnameh,"@ML@",ml);
+	replace(fnameh,"@ML@",ml)
 
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
@@ -132,7 +132,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c");
+	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
@@ -162,7 +162,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c");
+	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
@@ -287,13 +287,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 16 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"
@@ -380,7 +380,6 @@ else :
 os.system(deltext+" *.o")
 
 
-#print("Your section was ");	
+#print("Your section was ")
 #for i in range(0,ptr):
 #	print (selection[i])
-

--- a/version3/c/config32.py
+++ b/version3/c/config32.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,42 +45,42 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ff_"+tff+".c"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.c "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.c "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".c"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.c "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.c "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd=tb+"_"+base
 
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
@@ -84,7 +88,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -101,8 +105,8 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=14
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
-	os.system(copytext+" config_curve.h "+fnameh)
+	fnameh="config_curve_"+tc+".h"
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -117,32 +121,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="fp_"+tf+".c"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.c "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.c "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.c "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.c "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -150,13 +154,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".c"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.c "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.c "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -164,278 +168,278 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.c "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.c "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".c"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.c "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.c "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 		if cs == "128" :
 			fnamec="fp12_"+tf+".c"
 			fnameh="fp12_"+tf+".h"
 
-			os.system(copytext+" fp12.c "+fnamec)
-			os.system(copytext+" fp12.h "+fnameh)
+			run_in_shell(copytext+" fp12.c "+fnamec)
+			run_in_shell(copytext+" fp12.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="ecp2_"+tc+".c"
 			fnameh="ecp2_"+tc+".h"
 
-			os.system(copytext+" ecp2.c "+fnamec)
-			os.system(copytext+" ecp2.h "+fnameh)
+			run_in_shell(copytext+" ecp2.c "+fnamec)
+			run_in_shell(copytext+" ecp2.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="pair_"+tc+".c"
 			fnameh="pair_"+tc+".h"
 
-			os.system(copytext+" pair.c "+fnamec)
-			os.system(copytext+" pair.h "+fnameh)
+			run_in_shell(copytext+" pair.c "+fnamec)
+			run_in_shell(copytext+" pair.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin_"+tc+".c"
 			fnameh="mpin_"+tc+".h"
 
-			os.system(copytext+" mpin.c "+fnamec)
-			os.system(copytext+" mpin.h "+fnameh)
+			run_in_shell(copytext+" mpin.c "+fnamec)
+			run_in_shell(copytext+" mpin.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls_"+tc+".c"
 			fnameh="bls_"+tc+".h"
 
-			os.system(copytext+" bls.c "+fnamec)
-			os.system(copytext+" bls.h "+fnameh)
+			run_in_shell(copytext+" bls.c "+fnamec)
+			run_in_shell(copytext+" bls.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		if cs == "192" :
 			fnamec="fp8_"+tf+".c"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp24_"+tf+".c"
 			fnameh="fp24_"+tf+".h"
 
-			os.system(copytext+" fp24.c "+fnamec)
-			os.system(copytext+" fp24.h "+fnameh)
+			run_in_shell(copytext+" fp24.c "+fnamec)
+			run_in_shell(copytext+" fp24.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="ecp4_"+tc+".c"
 			fnameh="ecp4_"+tc+".h"
 
-			os.system(copytext+" ecp4.c "+fnamec)
-			os.system(copytext+" ecp4.h "+fnameh)
+			run_in_shell(copytext+" ecp4.c "+fnamec)
+			run_in_shell(copytext+" ecp4.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="pair192_"+tc+".c"
 			fnameh="pair192_"+tc+".h"
 
-			os.system(copytext+" pair192.c "+fnamec)
-			os.system(copytext+" pair192.h "+fnameh)
+			run_in_shell(copytext+" pair192.c "+fnamec)
+			run_in_shell(copytext+" pair192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin192_"+tc+".c"
 			fnameh="mpin192_"+tc+".h"
 
-			os.system(copytext+" mpin192.c "+fnamec)
-			os.system(copytext+" mpin192.h "+fnameh)
+			run_in_shell(copytext+" mpin192.c "+fnamec)
+			run_in_shell(copytext+" mpin192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)		
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls192_"+tc+".c"
 			fnameh="bls192_"+tc+".h"
 
-			os.system(copytext+" bls192.c "+fnamec)
-			os.system(copytext+" bls192.h "+fnameh)
+			run_in_shell(copytext+" bls192.c "+fnamec)
+			run_in_shell(copytext+" bls192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)	
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		if cs == "256" :
 
 			fnamec="fp8_"+tf+".c"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="ecp8_"+tc+".c"
 			fnameh="ecp8_"+tc+".h"
 
-			os.system(copytext+" ecp8.c "+fnamec)
-			os.system(copytext+" ecp8.h "+fnameh)
+			run_in_shell(copytext+" ecp8.c "+fnamec)
+			run_in_shell(copytext+" ecp8.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp16_"+tf+".c"
 			fnameh="fp16_"+tf+".h"
 
-			os.system(copytext+" fp16.c "+fnamec)
-			os.system(copytext+" fp16.h "+fnameh)
+			run_in_shell(copytext+" fp16.c "+fnamec)
+			run_in_shell(copytext+" fp16.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp48_"+tf+".c"
 			fnameh="fp48_"+tf+".h"
 
-			os.system(copytext+" fp48.c "+fnamec)
-			os.system(copytext+" fp48.h "+fnameh)
+			run_in_shell(copytext+" fp48.c "+fnamec)
+			run_in_shell(copytext+" fp48.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="pair256_"+tc+".c"
 			fnameh="pair256_"+tc+".h"
 
-			os.system(copytext+" pair256.c "+fnamec)
-			os.system(copytext+" pair256.h "+fnameh)
+			run_in_shell(copytext+" pair256.c "+fnamec)
+			run_in_shell(copytext+" pair256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin256_"+tc+".c"
 			fnameh="mpin256_"+tc+".h"
 
-			os.system(copytext+" mpin256.c "+fnamec)
-			os.system(copytext+" mpin256.h "+fnameh)
+			run_in_shell(copytext+" mpin256.c "+fnamec)
+			run_in_shell(copytext+" mpin256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)				
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls256_"+tc+".c"
 			fnameh="bls256_"+tc+".h"
 
-			os.system(copytext+" bls256.c "+fnamec)
-			os.system(copytext+" bls256.h "+fnameh)
+			run_in_shell(copytext+" bls256.c "+fnamec)
+			run_in_shell(copytext+" bls256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 replace("arch.h","@WL@","32")
 print("Elliptic Curves")
@@ -627,67 +631,67 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp8.*")
-os.system(deltext+" fp16.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp8.*")
+run_in_shell(deltext+" fp16.*")
 
 
-os.system(deltext+" fp12.*")
-os.system(deltext+" fp24.*")
-os.system(deltext+" fp48.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" fp24.*")
+run_in_shell(deltext+" fp48.*")
 
-os.system(deltext+" ecp2.*")
-os.system(deltext+" ecp4.*")
-os.system(deltext+" ecp8.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" ecp4.*")
+run_in_shell(deltext+" ecp8.*")
 
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
-os.system(deltext+" pair192.*")
-os.system(deltext+" mpin192.*")
-os.system(deltext+" bls192.*")
+run_in_shell(deltext+" pair192.*")
+run_in_shell(deltext+" mpin192.*")
+run_in_shell(deltext+" bls192.*")
 
-os.system(deltext+" pair256.*")
-os.system(deltext+" mpin256.*")
-os.system(deltext+" bls256.*")
+run_in_shell(deltext+" pair256.*")
+run_in_shell(deltext+" mpin256.*")
+run_in_shell(deltext+" bls256.*")
 
 # create library
-os.system("gcc -O3 -std=c99 -c randapi.c")
+run_in_shell("gcc -O3 -std=c99 -c randapi.c")
 if curve_selected :
-	os.system("gcc -O3 -std=c99 -c ecdh_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c ecdh_support.c")
 if rsa_selected :
-	os.system("gcc -O3 -std=c99 -c rsa_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c rsa_support.c")
 if pfcurve_selected :
-	os.system("gcc -O3 -std=c99 -c pbc_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c pbc_support.c")
 
-os.system("gcc -O3 -std=c99 -c hash.c")
-os.system("gcc -O3 -std=c99 -c rand.c")
-os.system("gcc -O3 -std=c99 -c oct.c")
-os.system("gcc -O3 -std=c99 -c aes.c")
-os.system("gcc -O3 -std=c99 -c gcm.c")
-os.system("gcc -O3 -std=c99 -c newhope.c")
+run_in_shell("gcc -O3 -std=c99 -c hash.c")
+run_in_shell("gcc -O3 -std=c99 -c rand.c")
+run_in_shell("gcc -O3 -std=c99 -c oct.c")
+run_in_shell("gcc -O3 -std=c99 -c aes.c")
+run_in_shell("gcc -O3 -std=c99 -c gcm.c")
+run_in_shell("gcc -O3 -std=c99 -c newhope.c")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
-	
-os.system(deltext+" *.o")
+	run_in_shell("ar rc amcl.a *.o")
+
+run_in_shell(deltext+" *.o")
 
 #print("Your section was ")
 #for i in range(0,ptr):

--- a/version3/c/config32.py
+++ b/version3/c/config32.py
@@ -36,7 +36,7 @@ def rsaset(tb,tff,nb,base,ml) :
 	os.system(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
-	replace(fnameh,"@ML@",ml);
+	replace(fnameh,"@ML@",ml)
 
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
@@ -136,7 +136,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c");
+	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
@@ -166,7 +166,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c");
+	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
@@ -493,13 +493,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 32 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"
@@ -689,7 +689,7 @@ else :
 	
 os.system(deltext+" *.o")
 
-#print("Your section was ");	
+#print("Your section was ")
 #for i in range(0,ptr):
 #	print (selection[i])
 

--- a/version3/c/config64.py
+++ b/version3/c/config64.py
@@ -36,7 +36,7 @@ def rsaset(tb,tff,nb,base,ml) :
 	os.system(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
-	replace(fnameh,"@ML@",ml);
+	replace(fnameh,"@ML@",ml)
 
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
@@ -132,7 +132,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c");
+	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
@@ -162,7 +162,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c");
+	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
@@ -488,13 +488,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 64 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"
@@ -684,7 +684,7 @@ else :
 os.system(deltext+" *.o")
 
 
-#print("Your section was ");	
+#print("Your section was ")
 #for i in range(0,ptr):
 #	print (selection[i])
 

--- a/version3/c/config64.py
+++ b/version3/c/config64.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,47 +45,47 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ff_"+tff+".c"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.c "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.c "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".c"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.c "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.c "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -96,8 +100,8 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=30
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
-	os.system(copytext+" config_curve.h "+fnameh)
+	fnameh="config_curve_"+tc+".h"
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -113,32 +117,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".c"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="fp_"+tf+".c"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.c "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.c "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_field_"+tf+".c")
 
 	fnamec="ecp_"+tc+".c"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.c "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.c "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -146,13 +150,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".c"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.c "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.c "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -160,277 +164,277 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("gcc -O3 -std=c99 -c "+fnamec)
+	run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
-	os.system("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
+	run_in_shell("gcc -O3 -std=c99 -c rom_curve_"+tc+".c")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.c "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.c "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".c"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.c "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.c "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("gcc -O3 -std=c99 -c "+fnamec)
+		run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		if cs == "128" :
 			fnamec="fp12_"+tf+".c"
 			fnameh="fp12_"+tf+".h"
 
-			os.system(copytext+" fp12.c "+fnamec)
-			os.system(copytext+" fp12.h "+fnameh)
+			run_in_shell(copytext+" fp12.c "+fnamec)
+			run_in_shell(copytext+" fp12.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			replace(fnameh,"ZZZ",tc)	
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			replace(fnameh,"ZZZ",tc)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="ecp2_"+tc+".c"
 			fnameh="ecp2_"+tc+".h"
 
-			os.system(copytext+" ecp2.c "+fnamec)
-			os.system(copytext+" ecp2.h "+fnameh)
+			run_in_shell(copytext+" ecp2.c "+fnamec)
+			run_in_shell(copytext+" ecp2.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="pair_"+tc+".c"
 			fnameh="pair_"+tc+".h"
 
-			os.system(copytext+" pair.c "+fnamec)
-			os.system(copytext+" pair.h "+fnameh)
+			run_in_shell(copytext+" pair.c "+fnamec)
+			run_in_shell(copytext+" pair.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin_"+tc+".c"
 			fnameh="mpin_"+tc+".h"
 
-			os.system(copytext+" mpin.c "+fnamec)
-			os.system(copytext+" mpin.h "+fnameh)
+			run_in_shell(copytext+" mpin.c "+fnamec)
+			run_in_shell(copytext+" mpin.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls_"+tc+".c"
 			fnameh="bls_"+tc+".h"
 
-			os.system(copytext+" bls.c "+fnamec)
-			os.system(copytext+" bls.h "+fnameh)
+			run_in_shell(copytext+" bls.c "+fnamec)
+			run_in_shell(copytext+" bls.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		if cs == "192" :
 			fnamec="fp8_"+tf+".c"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp24_"+tf+".c"
 			fnameh="fp24_"+tf+".h"
 
-			os.system(copytext+" fp24.c "+fnamec)
-			os.system(copytext+" fp24.h "+fnameh)
+			run_in_shell(copytext+" fp24.c "+fnamec)
+			run_in_shell(copytext+" fp24.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="ecp4_"+tc+".c"
 			fnameh="ecp4_"+tc+".h"
 
-			os.system(copytext+" ecp4.c "+fnamec)
-			os.system(copytext+" ecp4.h "+fnameh)
+			run_in_shell(copytext+" ecp4.c "+fnamec)
+			run_in_shell(copytext+" ecp4.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="pair192_"+tc+".c"
 			fnameh="pair192_"+tc+".h"
 
-			os.system(copytext+" pair192.c "+fnamec)
-			os.system(copytext+" pair192.h "+fnameh)
+			run_in_shell(copytext+" pair192.c "+fnamec)
+			run_in_shell(copytext+" pair192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin192_"+tc+".c"
 			fnameh="mpin192_"+tc+".h"
 
-			os.system(copytext+" mpin192.c "+fnamec)
-			os.system(copytext+" mpin192.h "+fnameh)
+			run_in_shell(copytext+" mpin192.c "+fnamec)
+			run_in_shell(copytext+" mpin192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls192_"+tc+".c"
 			fnameh="bls192_"+tc+".h"
 
-			os.system(copytext+" bls192.c "+fnamec)
-			os.system(copytext+" bls192.h "+fnameh)
+			run_in_shell(copytext+" bls192.c "+fnamec)
+			run_in_shell(copytext+" bls192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 		if cs == "256" :
 
 			fnamec="fp8_"+tf+".c"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="ecp8_"+tc+".c"
 			fnameh="ecp8_"+tc+".h"
 
-			os.system(copytext+" ecp8.c "+fnamec)
-			os.system(copytext+" ecp8.h "+fnameh)
+			run_in_shell(copytext+" ecp8.c "+fnamec)
+			run_in_shell(copytext+" ecp8.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp16_"+tf+".c"
 			fnameh="fp16_"+tf+".h"
 
-			os.system(copytext+" fp16.c "+fnamec)
-			os.system(copytext+" fp16.h "+fnameh)
+			run_in_shell(copytext+" fp16.c "+fnamec)
+			run_in_shell(copytext+" fp16.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="fp48_"+tf+".c"
 			fnameh="fp48_"+tf+".h"
 
-			os.system(copytext+" fp48.c "+fnamec)
-			os.system(copytext+" fp48.h "+fnameh)
+			run_in_shell(copytext+" fp48.c "+fnamec)
+			run_in_shell(copytext+" fp48.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 
 			fnamec="pair256_"+tc+".c"
 			fnameh="pair256_"+tc+".h"
 
-			os.system(copytext+" pair256.c "+fnamec)
-			os.system(copytext+" pair256.h "+fnameh)
+			run_in_shell(copytext+" pair256.c "+fnamec)
+			run_in_shell(copytext+" pair256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="mpin256_"+tc+".c"
 			fnameh="mpin256_"+tc+".h"
 
-			os.system(copytext+" mpin256.c "+fnamec)
-			os.system(copytext+" mpin256.h "+fnameh)
+			run_in_shell(copytext+" mpin256.c "+fnamec)
+			run_in_shell(copytext+" mpin256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 			fnamec="bls256_"+tc+".c"
 			fnameh="bls256_"+tc+".h"
 
-			os.system(copytext+" bls256.c "+fnamec)
-			os.system(copytext+" bls256.h "+fnameh)
+			run_in_shell(copytext+" bls256.c "+fnamec)
+			run_in_shell(copytext+" bls256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("gcc -O3 -std=c99 -c "+fnamec)
+			run_in_shell("gcc -O3 -std=c99 -c "+fnamec)
 
 replace("arch.h","@WL@","64")
 print("Elliptic Curves")
@@ -622,66 +626,66 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp8.*")
-os.system(deltext+" fp16.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp8.*")
+run_in_shell(deltext+" fp16.*")
 
-os.system(deltext+" fp12.*")
-os.system(deltext+" fp24.*")
-os.system(deltext+" fp48.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" fp24.*")
+run_in_shell(deltext+" fp48.*")
 
-os.system(deltext+" ecp2.*")
-os.system(deltext+" ecp4.*")
-os.system(deltext+" ecp8.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" ecp4.*")
+run_in_shell(deltext+" ecp8.*")
 
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
-os.system(deltext+" pair192.*")
-os.system(deltext+" mpin192.*")
-os.system(deltext+" bls192.*")
+run_in_shell(deltext+" pair192.*")
+run_in_shell(deltext+" mpin192.*")
+run_in_shell(deltext+" bls192.*")
 
-os.system(deltext+" pair256.*")
-os.system(deltext+" mpin256.*")
-os.system(deltext+" bls256.*")
+run_in_shell(deltext+" pair256.*")
+run_in_shell(deltext+" mpin256.*")
+run_in_shell(deltext+" bls256.*")
 
 # create library
-os.system("gcc -O3 -std=c99 -c randapi.c")
+run_in_shell("gcc -O3 -std=c99 -c randapi.c")
 if curve_selected :
-	os.system("gcc -O3 -std=c99 -c ecdh_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c ecdh_support.c")
 if rsa_selected :
-	os.system("gcc -O3 -std=c99 -c rsa_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c rsa_support.c")
 if pfcurve_selected :
-	os.system("gcc -O3 -std=c99 -c pbc_support.c")
+	run_in_shell("gcc -O3 -std=c99 -c pbc_support.c")
 
-os.system("gcc -O3 -std=c99 -c hash.c")
-os.system("gcc -O3 -std=c99 -c rand.c")
-os.system("gcc -O3 -std=c99 -c oct.c")
-os.system("gcc -O3 -std=c99 -c aes.c")
-os.system("gcc -O3 -std=c99 -c gcm.c")
-os.system("gcc -O3 -std=c99 -c newhope.c")
+run_in_shell("gcc -O3 -std=c99 -c hash.c")
+run_in_shell("gcc -O3 -std=c99 -c rand.c")
+run_in_shell("gcc -O3 -std=c99 -c oct.c")
+run_in_shell("gcc -O3 -std=c99 -c aes.c")
+run_in_shell("gcc -O3 -std=c99 -c gcm.c")
+run_in_shell("gcc -O3 -std=c99 -c newhope.c")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
+	run_in_shell("ar rc amcl.a *.o")
 
-os.system(deltext+" *.o")
+run_in_shell(deltext+" *.o")
 
 
 #print("Your section was ")

--- a/version3/cpp/config16.py
+++ b/version3/cpp/config16.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,47 +45,47 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ff_"+tff+".cpp"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.cpp "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.cpp "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".cpp"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.cpp "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.cpp "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -98,7 +102,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"@SH@",str(sh))
 
 	fnameh="config_curve_"+tc+".h"
-	os.system(copytext+" config_curve.h "+fnameh)
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -114,32 +118,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="fp_"+tf+".cpp"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.cpp "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.cpp "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_field_"+tf+".cpp")
+	run_in_shell("g++ -O3 -c rom_field_"+tf+".cpp")
 
 	fnamec="ecp_"+tc+".cpp"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.cpp "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.cpp "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -147,13 +151,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".cpp"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.cpp "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.cpp "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -161,99 +165,99 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_curve_"+tc+".cpp")
+	run_in_shell("g++ -O3 -c rom_curve_"+tc+".cpp")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".cpp"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.cpp "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.cpp "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".cpp"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.cpp "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.cpp "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="fp12_"+tf+".cpp"
 		fnameh="fp12_"+tf+".h"
 
-		os.system(copytext+" fp12.cpp "+fnamec)
-		os.system(copytext+" fp12.h "+fnameh)
+		run_in_shell(copytext+" fp12.cpp "+fnamec)
+		run_in_shell(copytext+" fp12.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="ecp2_"+tc+".cpp"
 		fnameh="ecp2_"+tc+".h"
 
-		os.system(copytext+" ecp2.cpp "+fnamec)
-		os.system(copytext+" ecp2.h "+fnameh)
+		run_in_shell(copytext+" ecp2.cpp "+fnamec)
+		run_in_shell(copytext+" ecp2.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="pair_"+tc+".cpp"
 		fnameh="pair_"+tc+".h"
 
-		os.system(copytext+" pair.cpp "+fnamec)
-		os.system(copytext+" pair.h "+fnameh)
+		run_in_shell(copytext+" pair.cpp "+fnamec)
+		run_in_shell(copytext+" pair.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="mpin_"+tc+".cpp"
 		fnameh="mpin_"+tc+".h"
 
-		os.system(copytext+" mpin.cpp "+fnamec)
-		os.system(copytext+" mpin.h "+fnameh)
+		run_in_shell(copytext+" mpin.cpp "+fnamec)
+		run_in_shell(copytext+" mpin.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="bls_"+tc+".cpp"
 		fnameh="bls_"+tc+".h"
 
-		os.system(copytext+" bls.cpp "+fnamec)
-		os.system(copytext+" bls.h "+fnameh)
+		run_in_shell(copytext+" bls.cpp "+fnamec)
+		run_in_shell(copytext+" bls.h "+fnameh)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 
 
@@ -339,49 +343,49 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp12.*")
-os.system(deltext+" ecp2.*")
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
 # create library
-os.system("g++ -O3 -c randapi.cpp")
+run_in_shell("g++ -O3 -c randapi.cpp")
 if curve_selected :
-	os.system("g++ -O3 -c ecdh_support.cpp")
+	run_in_shell("g++ -O3 -c ecdh_support.cpp")
 if rsa_selected :
-	os.system("g++ -O3 -c rsa_support.cpp")
+	run_in_shell("g++ -O3 -c rsa_support.cpp")
 if pfcurve_selected :
-	os.system("g++ -O3 -c pbc_support.cpp")
+	run_in_shell("g++ -O3 -c pbc_support.cpp")
 
-os.system("g++ -O3 -c hash.cpp")
-os.system("g++ -O3 -c rand.cpp")
-os.system("g++ -O3 -c oct.cpp")
-os.system("g++ -O3 -c aes.cpp")
-os.system("g++ -O3 -c gcm.cpp")
-os.system("g++ -O3 -c newhope.cpp")
+run_in_shell("g++ -O3 -c hash.cpp")
+run_in_shell("g++ -O3 -c rand.cpp")
+run_in_shell("g++ -O3 -c oct.cpp")
+run_in_shell("g++ -O3 -c aes.cpp")
+run_in_shell("g++ -O3 -c gcm.cpp")
+run_in_shell("g++ -O3 -c newhope.cpp")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
+	run_in_shell("ar rc amcl.a *.o")
 
-os.system(deltext+" *.o")
+run_in_shell(deltext+" *.o")
 
 
 #print("Your section was ")

--- a/version3/cpp/config16.py
+++ b/version3/cpp/config16.py
@@ -97,7 +97,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=6
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
+	fnameh="config_curve_"+tc+".h"
 	os.system(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
@@ -290,13 +290,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 16 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"

--- a/version3/cpp/config32.py
+++ b/version3/cpp/config32.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,47 +45,47 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ff_"+tff+".cpp"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.cpp "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.cpp "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".cpp"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.cpp "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.cpp "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -98,7 +102,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"@SH@",str(sh))
 
 	fnameh="config_curve_"+tc+".h"
-	os.system(copytext+" config_curve.h "+fnameh)
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -114,32 +118,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="fp_"+tf+".cpp"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.cpp "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.cpp "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_field_"+tf+".cpp")
+	run_in_shell("g++ -O3 -c rom_field_"+tf+".cpp")
 
 	fnamec="ecp_"+tc+".cpp"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.cpp "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.cpp "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -147,13 +151,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".cpp"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.cpp "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.cpp "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -161,280 +165,280 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_curve_"+tc+".cpp")
+	run_in_shell("g++ -O3 -c rom_curve_"+tc+".cpp")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".cpp"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.cpp "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.cpp "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".cpp"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.cpp "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.cpp "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		if cs == "128" :
 			fnamec="fp12_"+tf+".cpp"
 			fnameh="fp12_"+tf+".h"
 
-			os.system(copytext+" fp12.cpp "+fnamec)
-			os.system(copytext+" fp12.h "+fnameh)
+			run_in_shell(copytext+" fp12.cpp "+fnamec)
+			run_in_shell(copytext+" fp12.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="ecp2_"+tc+".cpp"
 			fnameh="ecp2_"+tc+".h"
 
-			os.system(copytext+" ecp2.cpp "+fnamec)
-			os.system(copytext+" ecp2.h "+fnameh)
+			run_in_shell(copytext+" ecp2.cpp "+fnamec)
+			run_in_shell(copytext+" ecp2.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="pair_"+tc+".cpp"
 			fnameh="pair_"+tc+".h"
 
-			os.system(copytext+" pair.cpp "+fnamec)
-			os.system(copytext+" pair.h "+fnameh)
+			run_in_shell(copytext+" pair.cpp "+fnamec)
+			run_in_shell(copytext+" pair.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin_"+tc+".cpp"
 			fnameh="mpin_"+tc+".h"
 
-			os.system(copytext+" mpin.cpp "+fnamec)
-			os.system(copytext+" mpin.h "+fnameh)
+			run_in_shell(copytext+" mpin.cpp "+fnamec)
+			run_in_shell(copytext+" mpin.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="bls_"+tc+".cpp"
 			fnameh="bls_"+tc+".h"
 
-			os.system(copytext+" bls.cpp "+fnamec)
-			os.system(copytext+" bls.h "+fnameh)
+			run_in_shell(copytext+" bls.cpp "+fnamec)
+			run_in_shell(copytext+" bls.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 		if cs == "192" :
 			fnamec="fp8_"+tf+".cpp"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.cpp "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.cpp "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp24_"+tf+".cpp"
 			fnameh="fp24_"+tf+".h"
 
-			os.system(copytext+" fp24.cpp "+fnamec)
-			os.system(copytext+" fp24.h "+fnameh)
+			run_in_shell(copytext+" fp24.cpp "+fnamec)
+			run_in_shell(copytext+" fp24.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="ecp4_"+tc+".cpp"
 			fnameh="ecp4_"+tc+".h"
 
-			os.system(copytext+" ecp4.cpp "+fnamec)
-			os.system(copytext+" ecp4.h "+fnameh)
+			run_in_shell(copytext+" ecp4.cpp "+fnamec)
+			run_in_shell(copytext+" ecp4.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="pair192_"+tc+".cpp"
 			fnameh="pair192_"+tc+".h"
 
-			os.system(copytext+" pair192.cpp "+fnamec)
-			os.system(copytext+" pair192.h "+fnameh)
+			run_in_shell(copytext+" pair192.cpp "+fnamec)
+			run_in_shell(copytext+" pair192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin192_"+tc+".cpp"
 			fnameh="mpin192_"+tc+".h"
 
-			os.system(copytext+" mpin192.cpp "+fnamec)
-			os.system(copytext+" mpin192.h "+fnameh)
+			run_in_shell(copytext+" mpin192.cpp "+fnamec)
+			run_in_shell(copytext+" mpin192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="bls192_"+tc+".cpp"
 			fnameh="bls192_"+tc+".h"
 
-			os.system(copytext+" bls192.cpp "+fnamec)
-			os.system(copytext+" bls192.h "+fnameh)
+			run_in_shell(copytext+" bls192.cpp "+fnamec)
+			run_in_shell(copytext+" bls192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 		if cs == "256" :
 
 			fnamec="fp8_"+tf+".cpp"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.cpp "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.cpp "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="ecp8_"+tc+".cpp"
 			fnameh="ecp8_"+tc+".h"
 
-			os.system(copytext+" ecp8.cpp "+fnamec)
-			os.system(copytext+" ecp8.h "+fnameh)
+			run_in_shell(copytext+" ecp8.cpp "+fnamec)
+			run_in_shell(copytext+" ecp8.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp16_"+tf+".cpp"
 			fnameh="fp16_"+tf+".h"
 
-			os.system(copytext+" fp16.cpp "+fnamec)
-			os.system(copytext+" fp16.h "+fnameh)
+			run_in_shell(copytext+" fp16.cpp "+fnamec)
+			run_in_shell(copytext+" fp16.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp48_"+tf+".cpp"
 			fnameh="fp48_"+tf+".h"
 
-			os.system(copytext+" fp48.cpp "+fnamec)
-			os.system(copytext+" fp48.h "+fnameh)
+			run_in_shell(copytext+" fp48.cpp "+fnamec)
+			run_in_shell(copytext+" fp48.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="pair256_"+tc+".cpp"
 			fnameh="pair256_"+tc+".h"
 
-			os.system(copytext+" pair256.cpp "+fnamec)
-			os.system(copytext+" pair256.h "+fnameh)
+			run_in_shell(copytext+" pair256.cpp "+fnamec)
+			run_in_shell(copytext+" pair256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin256_"+tc+".cpp"
 			fnameh="mpin256_"+tc+".h"
 
-			os.system(copytext+" mpin256.cpp "+fnamec)
-			os.system(copytext+" mpin256.h "+fnameh)
+			run_in_shell(copytext+" mpin256.cpp "+fnamec)
+			run_in_shell(copytext+" mpin256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="bls256_"+tc+".cpp"
 			fnameh="bls256_"+tc+".h"
 
-			os.system(copytext+" bls256.cpp "+fnamec)
-			os.system(copytext+" bls256.h "+fnameh)
+			run_in_shell(copytext+" bls256.cpp "+fnamec)
+			run_in_shell(copytext+" bls256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 replace("arch.h","@WL@","32")
 print("Elliptic Curves")
@@ -627,66 +631,66 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp8.*")
-os.system(deltext+" fp16.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp8.*")
+run_in_shell(deltext+" fp16.*")
 
-os.system(deltext+" fp12.*")
-os.system(deltext+" fp24.*")
-os.system(deltext+" fp48.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" fp24.*")
+run_in_shell(deltext+" fp48.*")
 
-os.system(deltext+" ecp2.*")
-os.system(deltext+" ecp4.*")
-os.system(deltext+" ecp8.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" ecp4.*")
+run_in_shell(deltext+" ecp8.*")
 
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
-os.system(deltext+" pair192.*")
-os.system(deltext+" mpin192.*")
-os.system(deltext+" bls192.*")
+run_in_shell(deltext+" pair192.*")
+run_in_shell(deltext+" mpin192.*")
+run_in_shell(deltext+" bls192.*")
 
-os.system(deltext+" pair256.*")
-os.system(deltext+" mpin256.*")
-os.system(deltext+" bls256.*")
+run_in_shell(deltext+" pair256.*")
+run_in_shell(deltext+" mpin256.*")
+run_in_shell(deltext+" bls256.*")
 
 # create library
-os.system("g++ -O3 -c randapi.cpp")
+run_in_shell("g++ -O3 -c randapi.cpp")
 if curve_selected :
-	os.system("g++ -O3 -c ecdh_support.cpp")
+	run_in_shell("g++ -O3 -c ecdh_support.cpp")
 if rsa_selected :
-	os.system("g++ -O3 -c rsa_support.cpp")
+	run_in_shell("g++ -O3 -c rsa_support.cpp")
 if pfcurve_selected :
-	os.system("g++ -O3 -c pbc_support.cpp")
+	run_in_shell("g++ -O3 -c pbc_support.cpp")
 
-os.system("g++ -O3 -c hash.cpp")
-os.system("g++ -O3 -c rand.cpp")
-os.system("g++ -O3 -c oct.cpp")
-os.system("g++ -O3 -c aes.cpp")
-os.system("g++ -O3 -c gcm.cpp")
-os.system("g++ -O3 -c newhope.cpp")
+run_in_shell("g++ -O3 -c hash.cpp")
+run_in_shell("g++ -O3 -c rand.cpp")
+run_in_shell("g++ -O3 -c oct.cpp")
+run_in_shell("g++ -O3 -c aes.cpp")
+run_in_shell("g++ -O3 -c gcm.cpp")
+run_in_shell("g++ -O3 -c newhope.cpp")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
+	run_in_shell("ar rc amcl.a *.o")
 
-os.system(deltext+" *.o")
+run_in_shell(deltext+" *.o")
 
 
 #print("Your section was ")

--- a/version3/cpp/config32.py
+++ b/version3/cpp/config32.py
@@ -97,7 +97,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=14
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
+	fnameh="config_curve_"+tc+".h"
 	os.system(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
@@ -493,13 +493,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 32 bit architecture, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"

--- a/version3/cpp/config64.py
+++ b/version3/cpp/config64.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -41,47 +45,47 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ff_"+tff+".cpp"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.cpp "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.cpp "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="rsa_"+tff+".cpp"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.cpp "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.cpp "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd="B"+tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -98,7 +102,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"@SH@",str(sh))
 
 	fnameh="config_curve_"+tc+".h"
-	os.system(copytext+" config_curve.h "+fnameh)
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -114,32 +118,32 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamec="big_"+bd+".cpp"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.cpp "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.cpp "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="fp_"+tf+".cpp"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.cpp "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.cpp "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_field_"+tf+".cpp")
+	run_in_shell("g++ -O3 -c rom_field_"+tf+".cpp")
 
 	fnamec="ecp_"+tc+".cpp"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.cpp "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.cpp "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -147,13 +151,13 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
 	fnamec="ecdh_"+tc+".cpp"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.cpp "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.cpp "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -161,280 +165,280 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("g++ -O3 -c "+fnamec)
+	run_in_shell("g++ -O3 -c "+fnamec)
 
-	os.system("g++ -O3 -c rom_curve_"+tc+".cpp")
+	run_in_shell("g++ -O3 -c rom_curve_"+tc+".cpp")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".cpp"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.cpp "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.cpp "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		fnamec="fp4_"+tf+".cpp"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.cpp "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.cpp "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("g++ -O3 -c "+fnamec)
+		run_in_shell("g++ -O3 -c "+fnamec)
 
 		if cs == "128" :
 			fnamec="fp12_"+tf+".cpp"
 			fnameh="fp12_"+tf+".h"
 
-			os.system(copytext+" fp12.cpp "+fnamec)
-			os.system(copytext+" fp12.h "+fnameh)
+			run_in_shell(copytext+" fp12.cpp "+fnamec)
+			run_in_shell(copytext+" fp12.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="ecp2_"+tc+".cpp"
 			fnameh="ecp2_"+tc+".h"
 
-			os.system(copytext+" ecp2.cpp "+fnamec)
-			os.system(copytext+" ecp2.h "+fnameh)
+			run_in_shell(copytext+" ecp2.cpp "+fnamec)
+			run_in_shell(copytext+" ecp2.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="pair_"+tc+".cpp"
 			fnameh="pair_"+tc+".h"
 
-			os.system(copytext+" pair.cpp "+fnamec)
-			os.system(copytext+" pair.h "+fnameh)
+			run_in_shell(copytext+" pair.cpp "+fnamec)
+			run_in_shell(copytext+" pair.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin_"+tc+".cpp"
 			fnameh="mpin_"+tc+".h"
 
-			os.system(copytext+" mpin.cpp "+fnamec)
-			os.system(copytext+" mpin.h "+fnameh)
+			run_in_shell(copytext+" mpin.cpp "+fnamec)
+			run_in_shell(copytext+" mpin.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 
 			fnamec="bls_"+tc+".cpp"
 			fnameh="bls_"+tc+".h"
 
-			os.system(copytext+" bls.cpp "+fnamec)
-			os.system(copytext+" bls.h "+fnameh)
+			run_in_shell(copytext+" bls.cpp "+fnamec)
+			run_in_shell(copytext+" bls.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 		if cs == "192" :
 			fnamec="fp8_"+tf+".cpp"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.cpp "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.cpp "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp24_"+tf+".cpp"
 			fnameh="fp24_"+tf+".h"
 
-			os.system(copytext+" fp24.cpp "+fnamec)
-			os.system(copytext+" fp24.h "+fnameh)
+			run_in_shell(copytext+" fp24.cpp "+fnamec)
+			run_in_shell(copytext+" fp24.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="ecp4_"+tc+".cpp"
 			fnameh="ecp4_"+tc+".h"
 
-			os.system(copytext+" ecp4.cpp "+fnamec)
-			os.system(copytext+" ecp4.h "+fnameh)
+			run_in_shell(copytext+" ecp4.cpp "+fnamec)
+			run_in_shell(copytext+" ecp4.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="pair192_"+tc+".cpp"
 			fnameh="pair192_"+tc+".h"
 
-			os.system(copytext+" pair192.cpp "+fnamec)
-			os.system(copytext+" pair192.h "+fnameh)
+			run_in_shell(copytext+" pair192.cpp "+fnamec)
+			run_in_shell(copytext+" pair192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin192_"+tc+".cpp"
 			fnameh="mpin192_"+tc+".h"
 
-			os.system(copytext+" mpin192.cpp "+fnamec)
-			os.system(copytext+" mpin192.h "+fnameh)
+			run_in_shell(copytext+" mpin192.cpp "+fnamec)
+			run_in_shell(copytext+" mpin192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="bls192_"+tc+".cpp"
 			fnameh="bls192_"+tc+".h"
 
-			os.system(copytext+" bls192.cpp "+fnamec)
-			os.system(copytext+" bls192.h "+fnameh)
+			run_in_shell(copytext+" bls192.cpp "+fnamec)
+			run_in_shell(copytext+" bls192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 		if cs == "256" :
 
 			fnamec="fp8_"+tf+".cpp"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.cpp "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.cpp "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="ecp8_"+tc+".cpp"
 			fnameh="ecp8_"+tc+".h"
 
-			os.system(copytext+" ecp8.cpp "+fnamec)
-			os.system(copytext+" ecp8.h "+fnameh)
+			run_in_shell(copytext+" ecp8.cpp "+fnamec)
+			run_in_shell(copytext+" ecp8.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp16_"+tf+".cpp"
 			fnameh="fp16_"+tf+".h"
 
-			os.system(copytext+" fp16.cpp "+fnamec)
-			os.system(copytext+" fp16.h "+fnameh)
+			run_in_shell(copytext+" fp16.cpp "+fnamec)
+			run_in_shell(copytext+" fp16.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="fp48_"+tf+".cpp"
 			fnameh="fp48_"+tf+".h"
 
-			os.system(copytext+" fp48.cpp "+fnamec)
-			os.system(copytext+" fp48.h "+fnameh)
+			run_in_shell(copytext+" fp48.cpp "+fnamec)
+			run_in_shell(copytext+" fp48.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 
 			fnamec="pair256_"+tc+".cpp"
 			fnameh="pair256_"+tc+".h"
 
-			os.system(copytext+" pair256.cpp "+fnamec)
-			os.system(copytext+" pair256.h "+fnameh)
+			run_in_shell(copytext+" pair256.cpp "+fnamec)
+			run_in_shell(copytext+" pair256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="mpin256_"+tc+".cpp"
 			fnameh="mpin256_"+tc+".h"
 
-			os.system(copytext+" mpin256.cpp "+fnamec)
-			os.system(copytext+" mpin256.h "+fnameh)
+			run_in_shell(copytext+" mpin256.cpp "+fnamec)
+			run_in_shell(copytext+" mpin256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 			fnamec="bls256_"+tc+".cpp"
 			fnameh="bls256_"+tc+".h"
 
-			os.system(copytext+" bls256.cpp "+fnamec)
-			os.system(copytext+" bls256.h "+fnameh)
+			run_in_shell(copytext+" bls256.cpp "+fnamec)
+			run_in_shell(copytext+" bls256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("g++ -O3 -c "+fnamec)
+			run_in_shell("g++ -O3 -c "+fnamec)
 
 replace("arch.h","@WL@","64")
 print("Elliptic Curves")
@@ -626,66 +630,66 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp8.*")
-os.system(deltext+" fp16.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp8.*")
+run_in_shell(deltext+" fp16.*")
 
-os.system(deltext+" fp12.*")
-os.system(deltext+" fp24.*")
-os.system(deltext+" fp48.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" fp24.*")
+run_in_shell(deltext+" fp48.*")
 
-os.system(deltext+" ecp2.*")
-os.system(deltext+" ecp4.*")
-os.system(deltext+" ecp8.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" ecp4.*")
+run_in_shell(deltext+" ecp8.*")
 
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
-os.system(deltext+" pair192.*")
-os.system(deltext+" mpin192.*")
-os.system(deltext+" bls192.*")
+run_in_shell(deltext+" pair192.*")
+run_in_shell(deltext+" mpin192.*")
+run_in_shell(deltext+" bls192.*")
 
-os.system(deltext+" pair256.*")
-os.system(deltext+" mpin256.*")
-os.system(deltext+" bls256.*")
+run_in_shell(deltext+" pair256.*")
+run_in_shell(deltext+" mpin256.*")
+run_in_shell(deltext+" bls256.*")
 
 # create library
-os.system("g++ -O3 -c randapi.cpp")
+run_in_shell("g++ -O3 -c randapi.cpp")
 if curve_selected :
-	os.system("g++ -O3 -c ecdh_support.cpp")
+	run_in_shell("g++ -O3 -c ecdh_support.cpp")
 if rsa_selected :
-	os.system("g++ -O3 -c rsa_support.cpp")
+	run_in_shell("g++ -O3 -c rsa_support.cpp")
 if pfcurve_selected :
-	os.system("g++ -O3 -c pbc_support.cpp")
+	run_in_shell("g++ -O3 -c pbc_support.cpp")
 
-os.system("g++ -O3 -c hash.cpp")
-os.system("g++ -O3 -c rand.cpp")
-os.system("g++ -O3 -c oct.cpp")
-os.system("g++ -O3 -c aes.cpp")
-os.system("g++ -O3 -c gcm.cpp")
-os.system("g++ -O3 -c newhope.cpp")
+run_in_shell("g++ -O3 -c hash.cpp")
+run_in_shell("g++ -O3 -c rand.cpp")
+run_in_shell("g++ -O3 -c oct.cpp")
+run_in_shell("g++ -O3 -c aes.cpp")
+run_in_shell("g++ -O3 -c gcm.cpp")
+run_in_shell("g++ -O3 -c newhope.cpp")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.o) do @echo %~nxi >> f.list")
-	os.system("ar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.o) do @echo %~nxi >> f.list")
+	run_in_shell("ar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("ar rc amcl.a *.o")
+	run_in_shell("ar rc amcl.a *.o")
 
-os.system(deltext+" *.o")
+run_in_shell(deltext+" *.o")
 
 
 #print("Your section was ")

--- a/version3/cpp/config64.py
+++ b/version3/cpp/config64.py
@@ -97,7 +97,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=30
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
+	fnameh="config_curve_"+tc+".h"
 	os.system(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
@@ -492,13 +492,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 64 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"
@@ -612,7 +612,7 @@ while ptr<max:
 	if x==27:
 		#256 is slower but may allow reuse of 256-bit BIGs used for elliptic curve
 		#512 is faster.. but best is 1024
-		#rsaset("960","RSA15360","120","58","16")  
+		#rsaset("960","RSA15360","120","58","16")
 		rsaset("1024","RSA2048","128","58","2")
 		#rsaset("512","RSA2048","64","60","4")
 		#rsaset("256","RSA2048","32","56","8")

--- a/version3/go/config32.py
+++ b/version3/go/config32.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -16,6 +17,9 @@ if sys.platform.startswith("win") :
 	copytext="copy "
 	deltext="del "
 	slashtext="\\"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 chosen=[]
 cptr=0
@@ -40,15 +44,15 @@ def rsaset(tb,nb,base,ml) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tb+slashtext
-	os.system("mkdir amcl"+slashtext+tb)
+	run_in_shell("mkdir amcl"+slashtext+tb)
 
-	os.system(copytext+"ARCH32.go "+fpath+"ARCH.go")
-	os.system(copytext+"BIG32.go "+fpath+"BIG.go")
-	os.system(copytext+"DBIG.go "+fpath+"DBIG.go")
-	os.system(copytext+"FF32.go "+fpath+"FF.go")
-	os.system(copytext+"RSA.go "+fpath+"RSA.go")
-	os.system(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
-	os.system(copytext+"CONFIG_FF.go "+fpath+"CONFIG_FF.go")
+	run_in_shell(copytext+"ARCH32.go "+fpath+"ARCH.go")
+	run_in_shell(copytext+"BIG32.go "+fpath+"BIG.go")
+	run_in_shell(copytext+"DBIG.go "+fpath+"DBIG.go")
+	run_in_shell(copytext+"FF32.go "+fpath+"FF.go")
+	run_in_shell(copytext+"RSA.go "+fpath+"RSA.go")
+	run_in_shell(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
+	run_in_shell(copytext+"CONFIG_FF.go "+fpath+"CONFIG_FF.go")
 
 	replace(fpath+"ARCH.go","XXX",tb)
 	replace(fpath+"CONFIG_BIG.go","XXX",tb)
@@ -71,18 +75,18 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tc+slashtext
-	os.system("mkdir amcl"+slashtext+tc)
+	run_in_shell("mkdir amcl"+slashtext+tc)
 
-	os.system(copytext+"ARCH32.go "+fpath+"ARCH.go")
-	os.system(copytext+"BIG32.go "+fpath+"BIG.go")
-	os.system(copytext+"DBIG.go "+fpath+"DBIG.go")
-	os.system(copytext+"FP.go "+fpath+"FP.go")
-	os.system(copytext+"ECP.go "+fpath+"ECP.go")
-	os.system(copytext+"ECDH.go "+fpath+"ECDH.go")
-	os.system(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
-	os.system(copytext+"CONFIG_FIELD.go "+fpath+"CONFIG_FIELD.go")
-	os.system(copytext+"CONFIG_CURVE.go "+fpath+"CONFIG_CURVE.go")
-	os.system(copytext+"ROM_"+tc+"_32.go "+fpath+"ROM.go")
+	run_in_shell(copytext+"ARCH32.go "+fpath+"ARCH.go")
+	run_in_shell(copytext+"BIG32.go "+fpath+"BIG.go")
+	run_in_shell(copytext+"DBIG.go "+fpath+"DBIG.go")
+	run_in_shell(copytext+"FP.go "+fpath+"FP.go")
+	run_in_shell(copytext+"ECP.go "+fpath+"ECP.go")
+	run_in_shell(copytext+"ECDH.go "+fpath+"ECDH.go")
+	run_in_shell(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
+	run_in_shell(copytext+"CONFIG_FIELD.go "+fpath+"CONFIG_FIELD.go")
+	run_in_shell(copytext+"CONFIG_CURVE.go "+fpath+"CONFIG_CURVE.go")
+	run_in_shell(copytext+"ROM_"+tc+"_32.go "+fpath+"ROM.go")
 
 	replace(fpath+"ARCH.go","XXX",tc)
 	replace(fpath+"BIG.go","XXX",tc)
@@ -130,18 +134,18 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	if pf != "NOT" :
 
-		os.system(copytext+"FP2.go "+fpath+"FP2.go")
-		os.system(copytext+"FP4.go "+fpath+"FP4.go")
+		run_in_shell(copytext+"FP2.go "+fpath+"FP2.go")
+		run_in_shell(copytext+"FP4.go "+fpath+"FP4.go")
 
 		replace(fpath+"FP2.go","XXX",tc)
 		replace(fpath+"FP4.go","XXX",tc)
 
 		if cs == "128" :
-			os.system(copytext+"ECP2.go "+fpath+"ECP2.go")
-			os.system(copytext+"FP12.go "+fpath+"FP12.go")
-			os.system(copytext+"PAIR.go "+fpath+"PAIR.go")
-			os.system(copytext+"MPIN.go "+fpath+"MPIN.go")
-			os.system(copytext+"BLS.go "+fpath+"BLS.go")
+			run_in_shell(copytext+"ECP2.go "+fpath+"ECP2.go")
+			run_in_shell(copytext+"FP12.go "+fpath+"FP12.go")
+			run_in_shell(copytext+"PAIR.go "+fpath+"PAIR.go")
+			run_in_shell(copytext+"MPIN.go "+fpath+"MPIN.go")
+			run_in_shell(copytext+"BLS.go "+fpath+"BLS.go")
 
 			replace(fpath+"FP12.go","XXX",tc)
 			replace(fpath+"ECP2.go","XXX",tc)
@@ -150,12 +154,12 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpath+"BLS.go","XXX",tc)
 
 		if cs == "192" :
-			os.system(copytext+"FP24.go "+fpath+"FP24.go")
-			os.system(copytext+"FP8.go "+fpath+"FP8.go")
-			os.system(copytext+"ECP4.go "+fpath+"ECP4.go")
-			os.system(copytext+"PAIR192.go "+fpath+"PAIR192.go")
-			os.system(copytext+"MPIN192.go "+fpath+"MPIN192.go")
-			os.system(copytext+"BLS192.go "+fpath+"BLS192.go")
+			run_in_shell(copytext+"FP24.go "+fpath+"FP24.go")
+			run_in_shell(copytext+"FP8.go "+fpath+"FP8.go")
+			run_in_shell(copytext+"ECP4.go "+fpath+"ECP4.go")
+			run_in_shell(copytext+"PAIR192.go "+fpath+"PAIR192.go")
+			run_in_shell(copytext+"MPIN192.go "+fpath+"MPIN192.go")
+			run_in_shell(copytext+"BLS192.go "+fpath+"BLS192.go")
 
 			replace(fpath+"FP24.go","XXX",tc)
 			replace(fpath+"FP8.go","XXX",tc)
@@ -166,13 +170,13 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 
 		if cs == "256" :
-			os.system(copytext+"FP48.go "+fpath+"FP48.go")
-			os.system(copytext+"FP16.go "+fpath+"FP16.go")
-			os.system(copytext+"FP8.go "+fpath+"FP8.go")
-			os.system(copytext+"ECP8.go "+fpath+"ECP8.go")
-			os.system(copytext+"PAIR256.go "+fpath+"PAIR256.go")
-			os.system(copytext+"MPIN256.go "+fpath+"MPIN256.go")
-			os.system(copytext+"BLS256.go "+fpath+"BLS256.go")
+			run_in_shell(copytext+"FP48.go "+fpath+"FP48.go")
+			run_in_shell(copytext+"FP16.go "+fpath+"FP16.go")
+			run_in_shell(copytext+"FP8.go "+fpath+"FP8.go")
+			run_in_shell(copytext+"ECP8.go "+fpath+"ECP8.go")
+			run_in_shell(copytext+"PAIR256.go "+fpath+"PAIR256.go")
+			run_in_shell(copytext+"MPIN256.go "+fpath+"MPIN256.go")
+			run_in_shell(copytext+"BLS256.go "+fpath+"BLS256.go")
 
 			replace(fpath+"FP48.go","XXX",tc)
 			replace(fpath+"FP16.go","XXX",tc)
@@ -183,13 +187,13 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpath+"BLS256.go","XXX",tc)
 
 
-os.system("mkdir amcl")
-os.system(copytext+ "HASH*.go amcl"+slashtext+".")
-os.system(copytext+ "SHA3.go amcl"+slashtext+".")
-os.system(copytext+ "RAND.go amcl"+slashtext+".")
-os.system(copytext+ "AES.go amcl"+slashtext+".")
-os.system(copytext+ "GCM.go amcl"+slashtext+".")
-os.system(copytext+ "NHS.go amcl"+slashtext+".")
+run_in_shell("mkdir amcl")
+run_in_shell(copytext+ "HASH*.go amcl"+slashtext+".")
+run_in_shell(copytext+ "SHA3.go amcl"+slashtext+".")
+run_in_shell(copytext+ "RAND.go amcl"+slashtext+".")
+run_in_shell(copytext+ "AES.go amcl"+slashtext+".")
+run_in_shell(copytext+ "GCM.go amcl"+slashtext+".")
+run_in_shell(copytext+ "NHS.go amcl"+slashtext+".")
 
 print("Elliptic Curves")
 print("1. ED25519")

--- a/version3/go/config32.py
+++ b/version3/go/config32.py
@@ -61,7 +61,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"CONFIG_BIG.go","@NB@",nb)
 	replace(fpath+"CONFIG_BIG.go","@BASE@",base)
 
-	replace(fpath+"CONFIG_FF.go","@ML@",ml);
+	replace(fpath+"CONFIG_FF.go","@ML@",ml)
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	global deltext,slashtext,copytext

--- a/version3/go/config64.py
+++ b/version3/go/config64.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -16,6 +17,9 @@ if sys.platform.startswith("win") :
 	copytext="copy "
 	deltext="del "
 	slashtext="\\"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 chosen=[]
 cptr=0
@@ -40,15 +44,15 @@ def rsaset(tb,nb,base,ml) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tb+slashtext
-	os.system("mkdir amcl"+slashtext+tb)
+	run_in_shell("mkdir amcl"+slashtext+tb)
 
-	os.system(copytext+"ARCH64.go "+fpath+"ARCH.go")
-	os.system(copytext+"BIG64.go "+fpath+"BIG.go")
-	os.system(copytext+"DBIG.go "+fpath+"DBIG.go")
-	os.system(copytext+"FF64.go "+fpath+"FF.go")
-	os.system(copytext+"RSA.go "+fpath+"RSA.go")
-	os.system(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
-	os.system(copytext+"CONFIG_FF.go "+fpath+"CONFIG_FF.go")
+	run_in_shell(copytext+"ARCH64.go "+fpath+"ARCH.go")
+	run_in_shell(copytext+"BIG64.go "+fpath+"BIG.go")
+	run_in_shell(copytext+"DBIG.go "+fpath+"DBIG.go")
+	run_in_shell(copytext+"FF64.go "+fpath+"FF.go")
+	run_in_shell(copytext+"RSA.go "+fpath+"RSA.go")
+	run_in_shell(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
+	run_in_shell(copytext+"CONFIG_FF.go "+fpath+"CONFIG_FF.go")
 
 	replace(fpath+"ARCH.go","XXX",tb)
 	replace(fpath+"CONFIG_BIG.go","XXX",tb)
@@ -71,18 +75,18 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tc+slashtext
-	os.system("mkdir amcl"+slashtext+tc)
+	run_in_shell("mkdir amcl"+slashtext+tc)
 
-	os.system(copytext+"ARCH64.go "+fpath+"ARCH.go")
-	os.system(copytext+"BIG64.go "+fpath+"BIG.go")
-	os.system(copytext+"DBIG.go "+fpath+"DBIG.go")
-	os.system(copytext+"FP.go "+fpath+"FP.go")
-	os.system(copytext+"ECP.go "+fpath+"ECP.go")
-	os.system(copytext+"ECDH.go "+fpath+"ECDH.go")
-	os.system(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
-	os.system(copytext+"CONFIG_FIELD.go "+fpath+"CONFIG_FIELD.go")
-	os.system(copytext+"CONFIG_CURVE.go "+fpath+"CONFIG_CURVE.go")
-	os.system(copytext+"ROM_"+tc+"_64.go "+fpath+"ROM.go")
+	run_in_shell(copytext+"ARCH64.go "+fpath+"ARCH.go")
+	run_in_shell(copytext+"BIG64.go "+fpath+"BIG.go")
+	run_in_shell(copytext+"DBIG.go "+fpath+"DBIG.go")
+	run_in_shell(copytext+"FP.go "+fpath+"FP.go")
+	run_in_shell(copytext+"ECP.go "+fpath+"ECP.go")
+	run_in_shell(copytext+"ECDH.go "+fpath+"ECDH.go")
+	run_in_shell(copytext+"CONFIG_BIG.go "+fpath+"CONFIG_BIG.go")
+	run_in_shell(copytext+"CONFIG_FIELD.go "+fpath+"CONFIG_FIELD.go")
+	run_in_shell(copytext+"CONFIG_CURVE.go "+fpath+"CONFIG_CURVE.go")
+	run_in_shell(copytext+"ROM_"+tc+"_64.go "+fpath+"ROM.go")
 
 	replace(fpath+"ARCH.go","XXX",tc)
 	replace(fpath+"BIG.go","XXX",tc)
@@ -130,19 +134,19 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	if pf != "NOT" :
 
-		os.system(copytext+"FP2.go "+fpath+"FP2.go")
-		os.system(copytext+"FP4.go "+fpath+"FP4.go")
+		run_in_shell(copytext+"FP2.go "+fpath+"FP2.go")
+		run_in_shell(copytext+"FP4.go "+fpath+"FP4.go")
 
 		replace(fpath+"FP2.go","XXX",tc)
 		replace(fpath+"FP4.go","XXX",tc)
 
 		if cs == "128" :
 
-			os.system(copytext+"ECP2.go "+fpath+"ECP2.go")
-			os.system(copytext+"FP12.go "+fpath+"FP12.go")
-			os.system(copytext+"PAIR.go "+fpath+"PAIR.go")
-			os.system(copytext+"MPIN.go "+fpath+"MPIN.go")
-			os.system(copytext+"BLS.go "+fpath+"BLS.go")
+			run_in_shell(copytext+"ECP2.go "+fpath+"ECP2.go")
+			run_in_shell(copytext+"FP12.go "+fpath+"FP12.go")
+			run_in_shell(copytext+"PAIR.go "+fpath+"PAIR.go")
+			run_in_shell(copytext+"MPIN.go "+fpath+"MPIN.go")
+			run_in_shell(copytext+"BLS.go "+fpath+"BLS.go")
 
 			replace(fpath+"FP12.go","XXX",tc)
 			replace(fpath+"ECP2.go","XXX",tc)
@@ -151,12 +155,12 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpath+"BLS.go","XXX",tc)
 
 		if cs == "192" :
-			os.system(copytext+"FP24.go "+fpath+"FP24.go")
-			os.system(copytext+"FP8.go "+fpath+"FP8.go")
-			os.system(copytext+"ECP4.go "+fpath+"ECP4.go")
-			os.system(copytext+"PAIR192.go "+fpath+"PAIR192.go")
-			os.system(copytext+"MPIN192.go "+fpath+"MPIN192.go")
-			os.system(copytext+"BLS192.go "+fpath+"BLS192.go")
+			run_in_shell(copytext+"FP24.go "+fpath+"FP24.go")
+			run_in_shell(copytext+"FP8.go "+fpath+"FP8.go")
+			run_in_shell(copytext+"ECP4.go "+fpath+"ECP4.go")
+			run_in_shell(copytext+"PAIR192.go "+fpath+"PAIR192.go")
+			run_in_shell(copytext+"MPIN192.go "+fpath+"MPIN192.go")
+			run_in_shell(copytext+"BLS192.go "+fpath+"BLS192.go")
 
 			replace(fpath+"FP24.go","XXX",tc)
 			replace(fpath+"FP8.go","XXX",tc)
@@ -166,13 +170,13 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpath+"BLS192.go","XXX",tc)
 
 		if cs == "256" :
-			os.system(copytext+"FP48.go "+fpath+"FP48.go")
-			os.system(copytext+"FP16.go "+fpath+"FP16.go")
-			os.system(copytext+"FP8.go "+fpath+"FP8.go")
-			os.system(copytext+"ECP8.go "+fpath+"ECP8.go")
-			os.system(copytext+"PAIR256.go "+fpath+"PAIR256.go")
-			os.system(copytext+"MPIN256.go "+fpath+"MPIN256.go")
-			os.system(copytext+"BLS256.go "+fpath+"BLS256.go")
+			run_in_shell(copytext+"FP48.go "+fpath+"FP48.go")
+			run_in_shell(copytext+"FP16.go "+fpath+"FP16.go")
+			run_in_shell(copytext+"FP8.go "+fpath+"FP8.go")
+			run_in_shell(copytext+"ECP8.go "+fpath+"ECP8.go")
+			run_in_shell(copytext+"PAIR256.go "+fpath+"PAIR256.go")
+			run_in_shell(copytext+"MPIN256.go "+fpath+"MPIN256.go")
+			run_in_shell(copytext+"BLS256.go "+fpath+"BLS256.go")
 
 			replace(fpath+"FP48.go","XXX",tc)
 			replace(fpath+"FP16.go","XXX",tc)
@@ -183,13 +187,13 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpath+"BLS256.go","XXX",tc)
 
 
-os.system("mkdir amcl")
-os.system(copytext+ "HASH*.go amcl"+slashtext+".")
-os.system(copytext+ "SHA3.go amcl"+slashtext+".")
-os.system(copytext+ "RAND.go amcl"+slashtext+".")
-os.system(copytext+ "AES.go amcl"+slashtext+".")
-os.system(copytext+ "GCM.go amcl"+slashtext+".")
-os.system(copytext+ "NHS.go amcl"+slashtext+".")
+run_in_shell("mkdir amcl")
+run_in_shell(copytext+ "HASH*.go amcl"+slashtext+".")
+run_in_shell(copytext+ "SHA3.go amcl"+slashtext+".")
+run_in_shell(copytext+ "RAND.go amcl"+slashtext+".")
+run_in_shell(copytext+ "AES.go amcl"+slashtext+".")
+run_in_shell(copytext+ "GCM.go amcl"+slashtext+".")
+run_in_shell(copytext+ "NHS.go amcl"+slashtext+".")
 
 print("Elliptic Curves")
 print("1. ED25519")

--- a/version3/go/config64.py
+++ b/version3/go/config64.py
@@ -61,7 +61,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"CONFIG_BIG.go","@NB@",nb)
 	replace(fpath+"CONFIG_BIG.go","@BASE@",base)
 
-	replace(fpath+"CONFIG_FF.go","@ML@",ml);
+	replace(fpath+"CONFIG_FF.go","@ML@",ml)
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	global deltext,slashtext,copytext
@@ -135,7 +135,7 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 		replace(fpath+"FP2.go","XXX",tc)
 		replace(fpath+"FP4.go","XXX",tc)
-		
+
 		if cs == "128" :
 
 			os.system(copytext+"ECP2.go "+fpath+"ECP2.go")

--- a/version3/java/config32.py
+++ b/version3/java/config32.py
@@ -74,7 +74,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"CONFIG_BIG.java","@NB@",nb)
 	replace(fpath+"CONFIG_BIG.java","@BASE@",base)
 
-	replace(fpath+"CONFIG_FF.java","@ML@",ml);
+	replace(fpath+"CONFIG_FF.java","@ML@",ml)
 
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
@@ -101,9 +101,9 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	os.system(copytext+"TestECDH.java "+fpathTest+"TestECDH.java")	#ms
 	os.system(copytext+"TesttimeECDH.java "+fpathTest+"TesttimeECDH.java")	#ms
 
-	replace(fpath+"CONFIG_BIG.java","XXX",tc)	
-	replace(fpath+"CONFIG_FIELD.java","XXX",tc)	
-	replace(fpath+"CONFIG_CURVE.java","XXX",tc)	
+	replace(fpath+"CONFIG_BIG.java","XXX",tc)
+	replace(fpath+"CONFIG_FIELD.java","XXX",tc)
+	replace(fpath+"CONFIG_CURVE.java","XXX",tc)
 	replace(fpath+"BIG.java","XXX",tc)
 	replace(fpath+"DBIG.java","XXX",tc)
 	replace(fpath+"FP.java","XXX",tc)
@@ -280,12 +280,12 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,curve security)
-# where "curve" is the common name for the elliptic curve   
+# where "curve" is the common name for the elliptic curve
 # big_length_bytes is the modulus size rounded up to a number of bytes
 # bits_in_base gives the number base used for 32 bit architectures, as n where the base is 2^n
 # modulus_bits is the actual bit length of the modulus.
@@ -352,22 +352,22 @@ while ptr<max:
 		curve_selected=True
 
 	if x==18:
-		curveset("BN254","32","28","254","3","NOT_SPECIAL","WEIERSTRASS","BN","D_TYPE","NEGATIVEX","66","128")  
+		curveset("BN254","32","28","254","3","NOT_SPECIAL","WEIERSTRASS","BN","D_TYPE","NEGATIVEX","66","128")
 		pfcurve_selected=True
 	if x==19:
-		curveset("BN254CX","32","28","254","3","NOT_SPECIAL","WEIERSTRASS","BN","D_TYPE","NEGATIVEX","66","128")  
+		curveset("BN254CX","32","28","254","3","NOT_SPECIAL","WEIERSTRASS","BN","D_TYPE","NEGATIVEX","66","128")
 		pfcurve_selected=True
 	if x==20:
-		curveset("BLS383","48","29","383","3","NOT_SPECIAL","WEIERSTRASS","BLS","M_TYPE","POSITIVEX","65","128") 
+		curveset("BLS383","48","29","383","3","NOT_SPECIAL","WEIERSTRASS","BLS","M_TYPE","POSITIVEX","65","128")
 		pfcurve_selected=True
 
 	if x==21:
-		curveset("BLS381","48","29","381","3","NOT_SPECIAL","WEIERSTRASS","BLS","M_TYPE","NEGATIVEX","65","128") 
+		curveset("BLS381","48","29","381","3","NOT_SPECIAL","WEIERSTRASS","BLS","M_TYPE","NEGATIVEX","65","128")
 		pfcurve_selected=True
 
 
 	if x==22:
-		curveset("FP256BN","32","28","256","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","NEGATIVEX","66","128") 
+		curveset("FP256BN","32","28","256","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","NEGATIVEX","66","128")
 		pfcurve_selected=True
 	if x==23:
 		curveset("FP512BN","64","29","512","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","POSITIVEX","130","128")

--- a/version3/java/config32.py
+++ b/version3/java/config32.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -19,6 +20,9 @@ if sys.platform.startswith("win") :
 	deltext="del "
 	slashtext="\\"
 	makedir="md "
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 amclpath = "amcl" + slashtext + "src" + slashtext + "main" + slashtext + "java" + slashtext + org1text + slashtext + org2text + slashtext + org3text +slashtext + "amcl"
 amclTestPath = "amcl" + slashtext + "src" + slashtext + "test" + slashtext + "java" + slashtext + org1text + slashtext + org2text + slashtext + org3text +slashtext + "amcl"
@@ -46,20 +50,20 @@ def rsaset(tb,nb,base,ml) :
 
 	fpath=amclpath+slashtext+tb+slashtext
 	fpathTest=amclTestPath+slashtext+tb+slashtext  #ms
-	os.system(makedir+amclpath+slashtext+tb)
-	os.system(makedir+amclTestPath+slashtext+tb)  #ms
+	run_in_shell(makedir+amclpath+slashtext+tb)
+	run_in_shell(makedir+amclTestPath+slashtext+tb)  #ms
 
-	os.system(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
-	os.system(copytext+"CONFIG_FF.java "+fpath+"CONFIG_FF.java")
-	os.system(copytext+"BIG32.java "+fpath+"BIG.java")
-	os.system(copytext+"DBIG32.java "+fpath+"DBIG.java")
-	os.system(copytext+"FF32.java "+fpath+"FF.java")
-	os.system(copytext+"RSA.java "+fpath+"RSA.java")
-	os.system(copytext+"private_key.java "+fpath+"private_key.java")
-	os.system(copytext+"public_key.java "+fpath+"public_key.java")	
-	os.system(copytext+"TestRSA.java "+fpathTest+"TestRSA.java")	#ms
-	os.system(copytext+"TesttimeRSA.java "+fpathTest+"TesttimeRSA.java")	#ms
-	
+	run_in_shell(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
+	run_in_shell(copytext+"CONFIG_FF.java "+fpath+"CONFIG_FF.java")
+	run_in_shell(copytext+"BIG32.java "+fpath+"BIG.java")
+	run_in_shell(copytext+"DBIG32.java "+fpath+"DBIG.java")
+	run_in_shell(copytext+"FF32.java "+fpath+"FF.java")
+	run_in_shell(copytext+"RSA.java "+fpath+"RSA.java")
+	run_in_shell(copytext+"private_key.java "+fpath+"private_key.java")
+	run_in_shell(copytext+"public_key.java "+fpath+"public_key.java")
+	run_in_shell(copytext+"TestRSA.java "+fpathTest+"TestRSA.java")	#ms
+	run_in_shell(copytext+"TesttimeRSA.java "+fpathTest+"TesttimeRSA.java")	#ms
+
 	replace(fpath+"CONFIG_BIG.java","XXX",tb)
 	replace(fpath+"CONFIG_FF.java","XXX",tb)
 	replace(fpath+"BIG.java","XXX",tb)
@@ -86,20 +90,20 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	fpath=amclpath+slashtext+tc+slashtext
 	fpathTest=amclTestPath+slashtext+tc+slashtext  #ms
-	os.system(makedir+amclpath+slashtext+tc)
-	os.system(makedir+amclTestPath+slashtext+tc)  #ms
+	run_in_shell(makedir+amclpath+slashtext+tc)
+	run_in_shell(makedir+amclTestPath+slashtext+tc)  #ms
 
-	os.system(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
-	os.system(copytext+"CONFIG_FIELD.java "+fpath+"CONFIG_FIELD.java")
-	os.system(copytext+"CONFIG_CURVE.java "+fpath+"CONFIG_CURVE.java")
-	os.system(copytext+"BIG32.java "+fpath+"BIG.java")
-	os.system(copytext+"DBIG32.java "+fpath+"DBIG.java")
-	os.system(copytext+"FP32.java "+fpath+"FP.java")
-	os.system(copytext+"ECP.java "+fpath+"ECP.java")
-	os.system(copytext+"ECDH.java "+fpath+"ECDH.java")
-	os.system(copytext+"ROM_"+tc+"_32.java "+fpath+"ROM.java")
-	os.system(copytext+"TestECDH.java "+fpathTest+"TestECDH.java")	#ms
-	os.system(copytext+"TesttimeECDH.java "+fpathTest+"TesttimeECDH.java")	#ms
+	run_in_shell(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
+	run_in_shell(copytext+"CONFIG_FIELD.java "+fpath+"CONFIG_FIELD.java")
+	run_in_shell(copytext+"CONFIG_CURVE.java "+fpath+"CONFIG_CURVE.java")
+	run_in_shell(copytext+"BIG32.java "+fpath+"BIG.java")
+	run_in_shell(copytext+"DBIG32.java "+fpath+"DBIG.java")
+	run_in_shell(copytext+"FP32.java "+fpath+"FP.java")
+	run_in_shell(copytext+"ECP.java "+fpath+"ECP.java")
+	run_in_shell(copytext+"ECDH.java "+fpath+"ECDH.java")
+	run_in_shell(copytext+"ROM_"+tc+"_32.java "+fpath+"ROM.java")
+	run_in_shell(copytext+"TestECDH.java "+fpathTest+"TestECDH.java")	#ms
+	run_in_shell(copytext+"TesttimeECDH.java "+fpathTest+"TesttimeECDH.java")	#ms
 
 	replace(fpath+"CONFIG_BIG.java","XXX",tc)
 	replace(fpath+"CONFIG_FIELD.java","XXX",tc)
@@ -146,22 +150,22 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		replace(fpath+"CONFIG_CURVE.java","@AK@","32")
 
 	if pf != "NOT" :
-		os.system(copytext+"FP2.java "+fpath+"FP2.java")
-		os.system(copytext+"FP4.java "+fpath+"FP4.java")
+		run_in_shell(copytext+"FP2.java "+fpath+"FP2.java")
+		run_in_shell(copytext+"FP4.java "+fpath+"FP4.java")
 
 		replace(fpath+"FP2.java","XXX",tc)
 		replace(fpath+"FP4.java","XXX",tc)
 
 		if cs == "128" :
 
-			os.system(copytext+"ECP2.java "+fpath+"ECP2.java")
-			os.system(copytext+"FP12.java "+fpath+"FP12.java")
-			os.system(copytext+"PAIR.java "+fpath+"PAIR.java")
-			os.system(copytext+"MPIN.java "+fpath+"MPIN.java")
-			os.system(copytext+"BLS.java "+fpath+"BLS.java")
-			os.system(copytext+"TestMPIN.java "+fpathTest+"TestMPIN.java")	#ms
-			os.system(copytext+"TestBLS.java "+fpathTest+"TestBLS.java")	#ms
-			os.system(copytext+"TesttimeMPIN.java "+fpathTest+"TesttimeMPIN.java")	#ms
+			run_in_shell(copytext+"ECP2.java "+fpath+"ECP2.java")
+			run_in_shell(copytext+"FP12.java "+fpath+"FP12.java")
+			run_in_shell(copytext+"PAIR.java "+fpath+"PAIR.java")
+			run_in_shell(copytext+"MPIN.java "+fpath+"MPIN.java")
+			run_in_shell(copytext+"BLS.java "+fpath+"BLS.java")
+			run_in_shell(copytext+"TestMPIN.java "+fpathTest+"TestMPIN.java")	#ms
+			run_in_shell(copytext+"TestBLS.java "+fpathTest+"TestBLS.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN.java "+fpathTest+"TesttimeMPIN.java")	#ms
 
 			replace(fpath+"FP12.java","XXX",tc)
 			replace(fpath+"ECP2.java","XXX",tc)
@@ -173,15 +177,15 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpathTest+"TesttimeMPIN.java","XXX",tc)  #ms
 
 		if cs == "192" :
-			os.system(copytext+"ECP4.java "+fpath+"ECP4.java")
-			os.system(copytext+"FP8.java "+fpath+"FP8.java")
-			os.system(copytext+"FP24.java "+fpath+"FP24.java")
-			os.system(copytext+"PAIR192.java "+fpath+"PAIR192.java")
-			os.system(copytext+"MPIN192.java "+fpath+"MPIN192.java")
-			os.system(copytext+"BLS192.java "+fpath+"BLS192.java")
-			os.system(copytext+"TestMPIN192.java "+fpathTest+"TestMPIN192.java")	#ms
-			os.system(copytext+"TestBLS192.java "+fpathTest+"TestBLS192.java")	#ms
-			os.system(copytext+"TesttimeMPIN192.java "+fpathTest+"TesttimeMPIN192.java")	#ms
+			run_in_shell(copytext+"ECP4.java "+fpath+"ECP4.java")
+			run_in_shell(copytext+"FP8.java "+fpath+"FP8.java")
+			run_in_shell(copytext+"FP24.java "+fpath+"FP24.java")
+			run_in_shell(copytext+"PAIR192.java "+fpath+"PAIR192.java")
+			run_in_shell(copytext+"MPIN192.java "+fpath+"MPIN192.java")
+			run_in_shell(copytext+"BLS192.java "+fpath+"BLS192.java")
+			run_in_shell(copytext+"TestMPIN192.java "+fpathTest+"TestMPIN192.java")	#ms
+			run_in_shell(copytext+"TestBLS192.java "+fpathTest+"TestBLS192.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN192.java "+fpathTest+"TesttimeMPIN192.java")	#ms
 
 			replace(fpath+"FP8.java","XXX",tc)
 			replace(fpath+"FP24.java","XXX",tc)
@@ -194,16 +198,16 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpathTest+"TesttimeMPIN192.java","XXX",tc)  #ms
 
 		if cs == "256" :
-			os.system(copytext+"FP8.java "+fpath+"FP8.java")
-			os.system(copytext+"ECP8.java "+fpath+"ECP8.java")
-			os.system(copytext+"FP16.java "+fpath+"FP16.java")
-			os.system(copytext+"FP48.java "+fpath+"FP48.java")
-			os.system(copytext+"PAIR256.java "+fpath+"PAIR256.java")
-			os.system(copytext+"MPIN256.java "+fpath+"MPIN256.java")
-			os.system(copytext+"BLS256.java "+fpath+"BLS256.java")
-			os.system(copytext+"TestMPIN256.java "+fpathTest+"TestMPIN256.java")	#ms
-			os.system(copytext+"TestBLS256.java "+fpathTest+"TestBLS256.java")	#ms
-			os.system(copytext+"TesttimeMPIN256.java "+fpathTest+"TesttimeMPIN256.java")	#ms
+			run_in_shell(copytext+"FP8.java "+fpath+"FP8.java")
+			run_in_shell(copytext+"ECP8.java "+fpath+"ECP8.java")
+			run_in_shell(copytext+"FP16.java "+fpath+"FP16.java")
+			run_in_shell(copytext+"FP48.java "+fpath+"FP48.java")
+			run_in_shell(copytext+"PAIR256.java "+fpath+"PAIR256.java")
+			run_in_shell(copytext+"MPIN256.java "+fpath+"MPIN256.java")
+			run_in_shell(copytext+"BLS256.java "+fpath+"BLS256.java")
+			run_in_shell(copytext+"TestMPIN256.java "+fpathTest+"TestMPIN256.java")	#ms
+			run_in_shell(copytext+"TestBLS256.java "+fpathTest+"TestBLS256.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN256.java "+fpathTest+"TesttimeMPIN256.java")	#ms
 
 			replace(fpath+"FP8.java","XXX",tc)
 			replace(fpath+"FP16.java","XXX",tc)
@@ -217,11 +221,11 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpathTest+"TesttimeMPIN256.java","XXX",tc)  #ms
 
 
-os.system(makedir + amclpath)
+run_in_shell(makedir + amclpath)
 
-os.system(copytext + "pom.xml " + "amcl" + slashtext + ".")
+run_in_shell(copytext + "pom.xml " + "amcl" + slashtext + ".")
 for file in ['HASH*.java', 'SHA3.java', 'RAND.java', 'AES.java', 'GCM.java', 'NHS.java']:
-	os.system(copytext + file + " " + amclpath+slashtext+".")
+	run_in_shell(copytext + file + " " + amclpath+slashtext+".")
 
 print("Elliptic Curves")
 print("1. ED25519")

--- a/version3/java/config64.py
+++ b/version3/java/config64.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -19,6 +20,9 @@ if sys.platform.startswith("win") :
 	deltext="del "
 	slashtext="\\"
 	makedir="md "
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 amclpath = "amcl" + slashtext + "src" + slashtext + "main" + slashtext + "java" + slashtext + org1text + slashtext + org2text + slashtext + org3text +slashtext + "amcl"
 amclTestPath = "amcl" + slashtext + "src" + slashtext + "test" + slashtext + "java" + slashtext + org1text + slashtext + org2text + slashtext + org3text +slashtext + "amcl"
@@ -46,19 +50,19 @@ def rsaset(tb,nb,base,ml) :
 
 	fpath=amclpath+slashtext+tb+slashtext
 	fpathTest=amclTestPath+slashtext+tb+slashtext #ms
-	os.system(makedir+amclpath+slashtext+tb)
-	os.system(makedir+amclTestPath+slashtext+tb) #ms
-	
-	os.system(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
-	os.system(copytext+"CONFIG_FF.java "+fpath+"CONFIG_FF.java")
-	os.system(copytext+"BIG64.java "+fpath+"BIG.java")
-	os.system(copytext+"DBIG64.java "+fpath+"DBIG.java")
-	os.system(copytext+"FF64.java "+fpath+"FF.java")
-	os.system(copytext+"RSA.java "+fpath+"RSA.java")
-	os.system(copytext+"private_key.java "+fpath+"private_key.java")
-	os.system(copytext+"public_key.java "+fpath+"public_key.java")	
-	os.system(copytext+"TestRSA.java "+fpathTest+"TestRSA.java") #ms
-	os.system(copytext+"TesttimeRSA.java "+fpathTest+"TesttimeRSA.java")	#ms
+	run_in_shell(makedir+amclpath+slashtext+tb)
+	run_in_shell(makedir+amclTestPath+slashtext+tb) #ms
+
+	run_in_shell(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
+	run_in_shell(copytext+"CONFIG_FF.java "+fpath+"CONFIG_FF.java")
+	run_in_shell(copytext+"BIG64.java "+fpath+"BIG.java")
+	run_in_shell(copytext+"DBIG64.java "+fpath+"DBIG.java")
+	run_in_shell(copytext+"FF64.java "+fpath+"FF.java")
+	run_in_shell(copytext+"RSA.java "+fpath+"RSA.java")
+	run_in_shell(copytext+"private_key.java "+fpath+"private_key.java")
+	run_in_shell(copytext+"public_key.java "+fpath+"public_key.java")
+	run_in_shell(copytext+"TestRSA.java "+fpathTest+"TestRSA.java") #ms
+	run_in_shell(copytext+"TesttimeRSA.java "+fpathTest+"TesttimeRSA.java")	#ms
 
 	replace(fpath+"CONFIG_BIG.java","XXX",tb)
 	replace(fpath+"CONFIG_FF.java","XXX",tb)
@@ -87,24 +91,24 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	fpath=amclpath+slashtext+tc+slashtext
 	fpathTest=amclTestPath+slashtext+tc+slashtext  #ms
-	os.system(makedir+amclpath+slashtext+tc)
-	os.system(makedir+amclTestPath+slashtext+tc)  #ms
+	run_in_shell(makedir+amclpath+slashtext+tc)
+	run_in_shell(makedir+amclTestPath+slashtext+tc)  #ms
 
-	os.system(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
-	os.system(copytext+"CONFIG_FIELD.java "+fpath+"CONFIG_FIELD.java")
-	os.system(copytext+"CONFIG_CURVE.java "+fpath+"CONFIG_CURVE.java")
-	os.system(copytext+"BIG64.java "+fpath+"BIG.java")
-	os.system(copytext+"DBIG64.java "+fpath+"DBIG.java")
-	os.system(copytext+"FP64.java "+fpath+"FP.java")
-	os.system(copytext+"ECP.java "+fpath+"ECP.java")
-	os.system(copytext+"ECDH.java "+fpath+"ECDH.java")
-	os.system(copytext+"ROM_"+tc+"_64.java "+fpath+"ROM.java")
-	os.system(copytext+"TestECDH.java "+fpathTest+"TestECDH.java")	#ms
-	os.system(copytext+"TesttimeECDH.java "+fpathTest+"TesttimeECDH.java")	#ms
-	
-	replace(fpath+"CONFIG_BIG.java","XXX",tc)	
-	replace(fpath+"CONFIG_FIELD.java","XXX",tc)	
-	replace(fpath+"CONFIG_CURVE.java","XXX",tc)	
+	run_in_shell(copytext+"CONFIG_BIG.java "+fpath+"CONFIG_BIG.java")
+	run_in_shell(copytext+"CONFIG_FIELD.java "+fpath+"CONFIG_FIELD.java")
+	run_in_shell(copytext+"CONFIG_CURVE.java "+fpath+"CONFIG_CURVE.java")
+	run_in_shell(copytext+"BIG64.java "+fpath+"BIG.java")
+	run_in_shell(copytext+"DBIG64.java "+fpath+"DBIG.java")
+	run_in_shell(copytext+"FP64.java "+fpath+"FP.java")
+	run_in_shell(copytext+"ECP.java "+fpath+"ECP.java")
+	run_in_shell(copytext+"ECDH.java "+fpath+"ECDH.java")
+	run_in_shell(copytext+"ROM_"+tc+"_64.java "+fpath+"ROM.java")
+	run_in_shell(copytext+"TestECDH.java "+fpathTest+"TestECDH.java")	#ms
+	run_in_shell(copytext+"TesttimeECDH.java "+fpathTest+"TesttimeECDH.java")	#ms
+
+	replace(fpath+"CONFIG_BIG.java","XXX",tc)
+	replace(fpath+"CONFIG_FIELD.java","XXX",tc)
+	replace(fpath+"CONFIG_CURVE.java","XXX",tc)
 	replace(fpath+"BIG.java","XXX",tc)
 	replace(fpath+"DBIG.java","XXX",tc)
 	replace(fpath+"FP.java","XXX",tc)
@@ -146,22 +150,22 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		replace(fpath+"CONFIG_CURVE.java","@AK@","32")
 
 	if pf != "NOT" :
-		os.system(copytext+"FP2.java "+fpath+"FP2.java")
-		os.system(copytext+"FP4.java "+fpath+"FP4.java")
+		run_in_shell(copytext+"FP2.java "+fpath+"FP2.java")
+		run_in_shell(copytext+"FP4.java "+fpath+"FP4.java")
 
 		replace(fpath+"FP2.java","XXX",tc)
 		replace(fpath+"FP4.java","XXX",tc)
 
 		if cs == "128" :
 
-			os.system(copytext+"ECP2.java "+fpath+"ECP2.java")
-			os.system(copytext+"FP12.java "+fpath+"FP12.java")
-			os.system(copytext+"PAIR.java "+fpath+"PAIR.java")
-			os.system(copytext+"MPIN.java "+fpath+"MPIN.java")
-			os.system(copytext+"BLS.java "+fpath+"BLS.java")
-			os.system(copytext+"TestMPIN.java "+fpathTest+"TestMPIN.java")	#ms
-			os.system(copytext+"TestBLS.java "+fpathTest+"TestBLS.java")	#ms
-			os.system(copytext+"TesttimeMPIN.java "+fpathTest+"TesttimeMPIN.java")	#ms
+			run_in_shell(copytext+"ECP2.java "+fpath+"ECP2.java")
+			run_in_shell(copytext+"FP12.java "+fpath+"FP12.java")
+			run_in_shell(copytext+"PAIR.java "+fpath+"PAIR.java")
+			run_in_shell(copytext+"MPIN.java "+fpath+"MPIN.java")
+			run_in_shell(copytext+"BLS.java "+fpath+"BLS.java")
+			run_in_shell(copytext+"TestMPIN.java "+fpathTest+"TestMPIN.java")	#ms
+			run_in_shell(copytext+"TestBLS.java "+fpathTest+"TestBLS.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN.java "+fpathTest+"TesttimeMPIN.java")	#ms
 
 			replace(fpath+"FP12.java","XXX",tc)
 			replace(fpath+"ECP2.java","XXX",tc)
@@ -173,15 +177,15 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpathTest+"TesttimeMPIN.java","XXX",tc)  #ms
 
 		if cs == "192" :
-			os.system(copytext+"ECP4.java "+fpath+"ECP4.java")
-			os.system(copytext+"FP8.java "+fpath+"FP8.java")
-			os.system(copytext+"FP24.java "+fpath+"FP24.java")
-			os.system(copytext+"PAIR192.java "+fpath+"PAIR192.java")
-			os.system(copytext+"MPIN192.java "+fpath+"MPIN192.java")
-			os.system(copytext+"BLS192.java "+fpath+"BLS192.java")
-			os.system(copytext+"TestMPIN192.java "+fpathTest+"TestMPIN192.java")	#ms
-			os.system(copytext+"TestBLS192.java "+fpathTest+"TestBLS192.java")	#ms
-			os.system(copytext+"TesttimeMPIN192.java "+fpathTest+"TesttimeMPIN192.java")	#ms
+			run_in_shell(copytext+"ECP4.java "+fpath+"ECP4.java")
+			run_in_shell(copytext+"FP8.java "+fpath+"FP8.java")
+			run_in_shell(copytext+"FP24.java "+fpath+"FP24.java")
+			run_in_shell(copytext+"PAIR192.java "+fpath+"PAIR192.java")
+			run_in_shell(copytext+"MPIN192.java "+fpath+"MPIN192.java")
+			run_in_shell(copytext+"BLS192.java "+fpath+"BLS192.java")
+			run_in_shell(copytext+"TestMPIN192.java "+fpathTest+"TestMPIN192.java")	#ms
+			run_in_shell(copytext+"TestBLS192.java "+fpathTest+"TestBLS192.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN192.java "+fpathTest+"TesttimeMPIN192.java")	#ms
 
 			replace(fpath+"FP8.java","XXX",tc)
 			replace(fpath+"FP24.java","XXX",tc)
@@ -194,16 +198,16 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			replace(fpathTest+"TesttimeMPIN192.java","XXX",tc)  #ms
 
 		if cs == "256" :
-			os.system(copytext+"FP8.java "+fpath+"FP8.java")
-			os.system(copytext+"ECP8.java "+fpath+"ECP8.java")
-			os.system(copytext+"FP16.java "+fpath+"FP16.java")
-			os.system(copytext+"FP48.java "+fpath+"FP48.java")
-			os.system(copytext+"PAIR256.java "+fpath+"PAIR256.java")
-			os.system(copytext+"MPIN256.java "+fpath+"MPIN256.java")
-			os.system(copytext+"BLS256.java "+fpath+"BLS256.java")
-			os.system(copytext+"TestMPIN256.java "+fpathTest+"TestMPIN256.java")	#ms
-			os.system(copytext+"TestBLS256.java "+fpathTest+"TestBLS256.java")	#ms
-			os.system(copytext+"TesttimeMPIN256.java "+fpathTest+"TesttimeMPIN256.java")	#ms
+			run_in_shell(copytext+"FP8.java "+fpath+"FP8.java")
+			run_in_shell(copytext+"ECP8.java "+fpath+"ECP8.java")
+			run_in_shell(copytext+"FP16.java "+fpath+"FP16.java")
+			run_in_shell(copytext+"FP48.java "+fpath+"FP48.java")
+			run_in_shell(copytext+"PAIR256.java "+fpath+"PAIR256.java")
+			run_in_shell(copytext+"MPIN256.java "+fpath+"MPIN256.java")
+			run_in_shell(copytext+"BLS256.java "+fpath+"BLS256.java")
+			run_in_shell(copytext+"TestMPIN256.java "+fpathTest+"TestMPIN256.java")	#ms
+			run_in_shell(copytext+"TestBLS256.java "+fpathTest+"TestBLS256.java")	#ms
+			run_in_shell(copytext+"TesttimeMPIN256.java "+fpathTest+"TesttimeMPIN256.java")	#ms
 
 			replace(fpath+"FP8.java","XXX",tc)
 			replace(fpath+"FP16.java","XXX",tc)
@@ -218,11 +222,11 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 
 
-os.system(makedir + amclpath)
+run_in_shell(makedir + amclpath)
 
-os.system(copytext + "pom.xml " + "amcl" + slashtext + ".")
+run_in_shell(copytext + "pom.xml " + "amcl" + slashtext + ".")
 for file in ['HASH*.java', 'SHA3.java', 'RAND.java', 'AES.java', 'GCM.java', 'NHS.java']:
-	os.system(copytext + file + " " + amclpath+slashtext+".")
+	run_in_shell(copytext + file + " " + amclpath+slashtext+".")
 
 print("Elliptic Curves")
 print("1. ED25519")

--- a/version3/java/config64.py
+++ b/version3/java/config64.py
@@ -75,7 +75,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"CONFIG_BIG.java","@NB@",nb)
 	replace(fpath+"CONFIG_BIG.java","@BASE@",base)
 
-	replace(fpath+"CONFIG_FF.java","@ML@",ml);
+	replace(fpath+"CONFIG_FF.java","@ML@",ml)
 
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
@@ -281,12 +281,12 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,curve security)
-# where "curve" is the common name for the elliptic curve   
+# where "curve" is the common name for the elliptic curve
 # big_length_bytes is the modulus size rounded up to a number of bytes
 # bits_in_base gives the number base used for 64 bit architectures, as n where the base is 2^n
 # modulus_bits is the actual bit length of the modulus.
@@ -367,7 +367,7 @@ while ptr<max:
 		pfcurve_selected=True
 
 	if x==22:
-		curveset("FP256BN","32","56","256","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","NEGATIVEX","66","128")  
+		curveset("FP256BN","32","56","256","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","NEGATIVEX","66","128")
 		pfcurve_selected=True
 	if x==23:
 		curveset("FP512BN","64","60","512","3","NOT_SPECIAL","WEIERSTRASS","BN","M_TYPE","POSITIVEX","130","128")

--- a/version3/python/config.py
+++ b/version3/python/config.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext = ""
@@ -17,6 +18,8 @@ if sys.platform.startswith("win"):
     deltext = "del "
     slashtext = "\\"
 
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 chosen = []
 cptr = 0
@@ -42,13 +45,13 @@ def curveset(tc, pf):
     cptr = cptr + 1
 
     fpath = tc + slashtext
-    os.system("mkdir " + tc)
+    run_in_shell("mkdir " + tc)
 
-    os.system(copytext + "big.py " + fpath + "big.py")
-    os.system(copytext + "fp.py " + fpath + "fp.py")
-    os.system(copytext + "ecp.py " + fpath + "ecp.py")
-    os.system(copytext + "ecdh.py " + fpath + "ecdh.py")
-    os.system(copytext + tc + ".py " + fpath + "curve.py")
+    run_in_shell(copytext + "big.py " + fpath + "big.py")
+    run_in_shell(copytext + "fp.py " + fpath + "fp.py")
+    run_in_shell(copytext + "ecp.py " + fpath + "ecp.py")
+    run_in_shell(copytext + "ecdh.py " + fpath + "ecdh.py")
+    run_in_shell(copytext + tc + ".py " + fpath + "curve.py")
 
     replace(fpath + "big.py", "XXX", tc)
     replace(fpath + "fp.py", "XXX", tc)
@@ -56,17 +59,17 @@ def curveset(tc, pf):
     replace(fpath + "ecdh.py", "XXX", tc)
 
     if pf != "NOT":
-        os.system(copytext + "fp2.py " + fpath + "fp2.py")
-        os.system(copytext + "fp4.py " + fpath + "fp4.py")
+        run_in_shell(copytext + "fp2.py " + fpath + "fp2.py")
+        run_in_shell(copytext + "fp4.py " + fpath + "fp4.py")
 
         replace(fpath + "fp2.py", "XXX", tc)
         replace(fpath + "fp4.py", "XXX", tc)
 
-        os.system(copytext + "ecp2.py " + fpath + "ecp2.py")
-        os.system(copytext + "fp12.py " + fpath + "fp12.py")
-        os.system(copytext + "pair.py " + fpath + "pair.py")
-        os.system(copytext + "mpin.py " + fpath + "mpin.py")
-        os.system(copytext + "bls.py " + fpath + "bls.py")
+        run_in_shell(copytext + "ecp2.py " + fpath + "ecp2.py")
+        run_in_shell(copytext + "fp12.py " + fpath + "fp12.py")
+        run_in_shell(copytext + "pair.py " + fpath + "pair.py")
+        run_in_shell(copytext + "mpin.py " + fpath + "mpin.py")
+        run_in_shell(copytext + "bls.py " + fpath + "bls.py")
 
         replace(fpath + "fp12.py", "XXX", tc)
         replace(fpath + "ecp2.py", "XXX", tc)
@@ -154,25 +157,25 @@ while ptr < max:
         pfcurve_selected = True
 
 
-os.system(deltext + " big.py")
-os.system(deltext + " fp.py")
-os.system(deltext + " ecp.py")
-os.system(deltext + " ecdh.py")
-os.system(deltext + " fp2.py")
-os.system(deltext + " fp4.py")
-os.system(deltext + " fp12.py")
-os.system(deltext + " mpin.py")
-os.system(deltext + " bls.py")
-os.system(deltext + " pair.py")
-os.system(deltext + " ecp2.py")
-os.system(deltext + " c25519.py")
-os.system(deltext + " ed25519.py")
-os.system(deltext + " nist256.py")
-os.system(deltext + " bn254.py")
-os.system(deltext + " bn254cx.py")
-os.system(deltext + " bls383.py")
-os.system(deltext + " goldilocks.py")
-os.system(deltext + " bls381.py")
-os.system(deltext + " nist384.py")
-os.system(deltext + " nist521.py")
-os.system(deltext + " sec256k1.py")
+run_in_shell(deltext + " big.py")
+run_in_shell(deltext + " fp.py")
+run_in_shell(deltext + " ecp.py")
+run_in_shell(deltext + " ecdh.py")
+run_in_shell(deltext + " fp2.py")
+run_in_shell(deltext + " fp4.py")
+run_in_shell(deltext + " fp12.py")
+run_in_shell(deltext + " mpin.py")
+run_in_shell(deltext + " bls.py")
+run_in_shell(deltext + " pair.py")
+run_in_shell(deltext + " ecp2.py")
+run_in_shell(deltext + " c25519.py")
+run_in_shell(deltext + " ed25519.py")
+run_in_shell(deltext + " nist256.py")
+run_in_shell(deltext + " bn254.py")
+run_in_shell(deltext + " bn254cx.py")
+run_in_shell(deltext + " bls383.py")
+run_in_shell(deltext + " goldilocks.py")
+run_in_shell(deltext + " bls381.py")
+run_in_shell(deltext + " nist384.py")
+run_in_shell(deltext + " nist521.py")
+run_in_shell(deltext + " sec256k1.py")

--- a/version3/swift/config32.py
+++ b/version3/swift/config32.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -12,6 +13,9 @@ if sys.platform.startswith("win") :
 	copytext="copy "
 	deltext="del "
 	slashtext="\\"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 chosen=[]
 cptr=0
@@ -36,14 +40,14 @@ def rsaset(tb,nb,base,ml) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tb+slashtext
-	os.system("mkdir amcl"+slashtext+tb)
+	run_in_shell("mkdir amcl"+slashtext+tb)
 
-	os.system(copytext+"big.swift "+fpath+"big.swift")
-	os.system(copytext+"config_big.swift "+fpath+"config_big.swift")
-	os.system(copytext+"config_ff.swift "+fpath+"config_ff.swift")
-	os.system(copytext+"dbig.swift "+fpath+"dbig.swift")
-	os.system(copytext+"ff.swift "+fpath+"ff.swift")
-	os.system(copytext+"rsa.swift "+fpath+"rsa.swift")
+	run_in_shell(copytext+"big.swift "+fpath+"big.swift")
+	run_in_shell(copytext+"config_big.swift "+fpath+"config_big.swift")
+	run_in_shell(copytext+"config_ff.swift "+fpath+"config_ff.swift")
+	run_in_shell(copytext+"dbig.swift "+fpath+"dbig.swift")
+	run_in_shell(copytext+"ff.swift "+fpath+"ff.swift")
+	run_in_shell(copytext+"rsa.swift "+fpath+"rsa.swift")
 
 	replace(fpath+"config_big.swift","@NB@",nb)
 	replace(fpath+"config_big.swift","@BASE32@",base)
@@ -51,9 +55,9 @@ def rsaset(tb,nb,base,ml) :
 
 	replace(fpath+"config_ff.swift","@ML@",ml)
 
-	os.system("swiftc -DD32 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
-	os.system(deltext+fpath+"*.*")
-	os.system("rmdir amcl"+slashtext+tb)
+	run_in_shell("swiftc -DD32 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
+	run_in_shell(deltext+fpath+"*.*")
+	run_in_shell("rmdir amcl"+slashtext+tb)
 
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
@@ -64,16 +68,16 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tc+slashtext
-	os.system("mkdir amcl"+slashtext+tc)
+	run_in_shell("mkdir amcl"+slashtext+tc)
 
-	os.system(copytext+"big.swift "+fpath+"big.swift")
-	os.system(copytext+"config_big.swift "+fpath+"config_big.swift")
-	os.system(copytext+"config_field.swift "+fpath+"config_field.swift")
-	os.system(copytext+"config_curve.swift "+fpath+"config_curve.swift")
-	os.system(copytext+"dbig.swift "+fpath+"dbig.swift")
-	os.system(copytext+"fp.swift "+fpath+"fp.swift")
-	os.system(copytext+"ecp.swift "+fpath+"ecp.swift")
-	os.system(copytext+"rom_"+tc+".swift "+fpath+"rom.swift")
+	run_in_shell(copytext+"big.swift "+fpath+"big.swift")
+	run_in_shell(copytext+"config_big.swift "+fpath+"config_big.swift")
+	run_in_shell(copytext+"config_field.swift "+fpath+"config_field.swift")
+	run_in_shell(copytext+"config_curve.swift "+fpath+"config_curve.swift")
+	run_in_shell(copytext+"dbig.swift "+fpath+"dbig.swift")
+	run_in_shell(copytext+"fp.swift "+fpath+"fp.swift")
+	run_in_shell(copytext+"ecp.swift "+fpath+"ecp.swift")
+	run_in_shell(copytext+"rom_"+tc+".swift "+fpath+"rom.swift")
 
 	replace(fpath+"config_big.swift","@NB@",nb)
 	replace(fpath+"config_big.swift","@BASE32@",base)
@@ -111,47 +115,47 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	if pf != "NOT" :
 
-		os.system(copytext+"fp2.swift "+fpath+"fp2.swift")
-		os.system(copytext+"fp4.swift "+fpath+"fp4.swift")
+		run_in_shell(copytext+"fp2.swift "+fpath+"fp2.swift")
+		run_in_shell(copytext+"fp4.swift "+fpath+"fp4.swift")
 		if cs == "128" :
-			os.system(copytext+"ecp2.swift "+fpath+"ecp2.swift")
-			os.system(copytext+"fp12.swift "+fpath+"fp12.swift")
-			os.system(copytext+"pair.swift "+fpath+"pair.swift")
-			os.system(copytext+"mpin.swift "+fpath+"mpin.swift")
-			os.system(copytext+"bls.swift "+fpath+"bls.swift")
+			run_in_shell(copytext+"ecp2.swift "+fpath+"ecp2.swift")
+			run_in_shell(copytext+"fp12.swift "+fpath+"fp12.swift")
+			run_in_shell(copytext+"pair.swift "+fpath+"pair.swift")
+			run_in_shell(copytext+"mpin.swift "+fpath+"mpin.swift")
+			run_in_shell(copytext+"bls.swift "+fpath+"bls.swift")
 		if cs == "192" :
-			os.system(copytext+"fp8.swift "+fpath+"fp8.swift")
-			os.system(copytext+"ecp4.swift "+fpath+"ecp4.swift")
-			os.system(copytext+"fp24.swift "+fpath+"fp24.swift")
-			os.system(copytext+"pair192.swift "+fpath+"pair192.swift")
-			os.system(copytext+"mpin192.swift "+fpath+"mpin192.swift")
-			os.system(copytext+"bls192.swift "+fpath+"bls192.swift")
+			run_in_shell(copytext+"fp8.swift "+fpath+"fp8.swift")
+			run_in_shell(copytext+"ecp4.swift "+fpath+"ecp4.swift")
+			run_in_shell(copytext+"fp24.swift "+fpath+"fp24.swift")
+			run_in_shell(copytext+"pair192.swift "+fpath+"pair192.swift")
+			run_in_shell(copytext+"mpin192.swift "+fpath+"mpin192.swift")
+			run_in_shell(copytext+"bls192.swift "+fpath+"bls192.swift")
 		if cs == "256" :
-			os.system(copytext+"fp8.swift "+fpath+"fp8.swift")
-			os.system(copytext+"fp16.swift "+fpath+"fp16.swift")
-			os.system(copytext+"ecp8.swift "+fpath+"ecp8.swift")
-			os.system(copytext+"fp48.swift "+fpath+"fp48.swift")
-			os.system(copytext+"pair256.swift "+fpath+"pair256.swift")
-			os.system(copytext+"mpin256.swift "+fpath+"mpin256.swift")
-			os.system(copytext+"bls256.swift "+fpath+"bls256.swift")
+			run_in_shell(copytext+"fp8.swift "+fpath+"fp8.swift")
+			run_in_shell(copytext+"fp16.swift "+fpath+"fp16.swift")
+			run_in_shell(copytext+"ecp8.swift "+fpath+"ecp8.swift")
+			run_in_shell(copytext+"fp48.swift "+fpath+"fp48.swift")
+			run_in_shell(copytext+"pair256.swift "+fpath+"pair256.swift")
+			run_in_shell(copytext+"mpin256.swift "+fpath+"mpin256.swift")
+			run_in_shell(copytext+"bls256.swift "+fpath+"bls256.swift")
 	else :
-		os.system(copytext+"ecdh.swift "+fpath+"ecdh.swift")
+		run_in_shell(copytext+"ecdh.swift "+fpath+"ecdh.swift")
 
 
-	os.system("swiftc -DD32 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tc)
-	os.system(deltext+fpath+"*.*")
-	os.system("rmdir amcl"+slashtext+tc)
+	run_in_shell("swiftc -DD32 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tc)
+	run_in_shell(deltext+fpath+"*.*")
+	run_in_shell("rmdir amcl"+slashtext+tc)
 
 
-os.system("mkdir amcl")
-os.system(copytext+ "hash*.swift amcl"+slashtext+".")
-os.system(copytext+ "sha3.swift amcl"+slashtext+".")
-os.system(copytext+ "rand.swift amcl"+slashtext+".")
-os.system(copytext+ "aes.swift amcl"+slashtext+".")
-os.system(copytext+ "gcm.swift amcl"+slashtext+".")
-os.system(copytext+ "nhs.swift amcl"+slashtext+".")
+run_in_shell("mkdir amcl")
+run_in_shell(copytext+ "hash*.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "sha3.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "rand.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "aes.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "gcm.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "nhs.swift amcl"+slashtext+".")
 
-os.system("swiftc amcl"+slashtext+"*.swift -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name amcl")
+run_in_shell("swiftc amcl"+slashtext+"*.swift -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name amcl")
 
 print("Elliptic Curves")
 print("1. ed25519")
@@ -336,29 +340,29 @@ while ptr<max:
 		rsaset("rsa4096","64","29","8")
 		rsa_selected=True
 
-os.system(deltext+" hash*.swift")
-os.system(deltext+" sha3.swift")
-os.system(deltext+" aes.swift")
-os.system(deltext+" rand.swift")
-os.system(deltext+" gcm.swift")
-os.system(deltext+" nhs.swift")
+run_in_shell(deltext+" hash*.swift")
+run_in_shell(deltext+" sha3.swift")
+run_in_shell(deltext+" aes.swift")
+run_in_shell(deltext+" rand.swift")
+run_in_shell(deltext+" gcm.swift")
+run_in_shell(deltext+" nhs.swift")
 
-os.system(deltext+" big.swift")
-os.system(deltext+" dbig.swift")
-os.system(deltext+" fp*.swift")
-os.system(deltext+" config*.swift")
+run_in_shell(deltext+" big.swift")
+run_in_shell(deltext+" dbig.swift")
+run_in_shell(deltext+" fp*.swift")
+run_in_shell(deltext+" config*.swift")
 
-os.system(deltext+" ecp*.swift")
-os.system(deltext+" ecdh.swift")
-os.system(deltext+" ff.swift")
-os.system(deltext+" rsa.swift")
-os.system(deltext+" pair*.swift")
-os.system(deltext+" mpin*.swift")
-os.system(deltext+" bls*.swift")
-os.system(deltext+" rom*.swift")
+run_in_shell(deltext+" ecp*.swift")
+run_in_shell(deltext+" ecdh.swift")
+run_in_shell(deltext+" ff.swift")
+run_in_shell(deltext+" rsa.swift")
+run_in_shell(deltext+" pair*.swift")
+run_in_shell(deltext+" mpin*.swift")
+run_in_shell(deltext+" bls*.swift")
+run_in_shell(deltext+" rom*.swift")
 
-os.system(deltext+"amcl"+slashtext+"*.*")
-os.system("rmdir amcl")
+run_in_shell(deltext+"amcl"+slashtext+"*.*")
+run_in_shell("rmdir amcl")
 
 # create library
 

--- a/version3/swift/config32.py
+++ b/version3/swift/config32.py
@@ -49,7 +49,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"config_big.swift","@BASE32@",base)
 	replace(fpath+"config_big.swift","@BASE64@",base)
 
-	replace(fpath+"config_ff.swift","@ML@",ml);
+	replace(fpath+"config_ff.swift","@ML@",ml)
 
 	os.system("swiftc -DD32 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
 	os.system(deltext+fpath+"*.*")
@@ -209,12 +209,12 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,curve security)
-# where "curve" is the common name for the elliptic curve   
+# where "curve" is the common name for the elliptic curve
 # big_length_bytes is the modulus size rounded up to a number of bytes
 # bits_in_base gives the number base used for 32 bit architectures, as n where the base is 2^n
 # modulus_bits is the actual bit length of the modulus.

--- a/version3/swift/config64.py
+++ b/version3/swift/config64.py
@@ -50,7 +50,7 @@ def rsaset(tb,nb,base,ml) :
 	replace(fpath+"config_big.swift","@BASE64@",base)
 
 
-	replace(fpath+"config_ff.swift","@ML@",ml);
+	replace(fpath+"config_ff.swift","@ML@",ml)
 
 	os.system("swiftc -DD64 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
 	os.system(deltext+fpath+"*.*")
@@ -97,7 +97,7 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 	replace(fpath+"config_curve.swift","@ST@",stw)
 	replace(fpath+"config_curve.swift","@SX@",sx)
-	replace(fpath+"config_curve.swift","@AB@",ab)	
+	replace(fpath+"config_curve.swift","@AB@",ab)
 
 	if cs == "128" :
 		replace(fpath+"config_curve.swift","@HT@","32")
@@ -209,12 +209,12 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,curve security)
-# where "curve" is the common name for the elliptic curve   
+# where "curve" is the common name for the elliptic curve
 # big_length_bytes is the modulus size rounded up to a number of bytes
 # bits_in_base gives the number base used for 32 bit architectures, as n where the base is 2^n
 # modulus_bits is the actual bit length of the modulus.

--- a/version3/swift/config64.py
+++ b/version3/swift/config64.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -12,6 +13,9 @@ if sys.platform.startswith("win") :
 	copytext="copy "
 	deltext="del "
 	slashtext="\\"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 chosen=[]
 cptr=0
@@ -36,14 +40,14 @@ def rsaset(tb,nb,base,ml) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tb+slashtext
-	os.system("mkdir amcl"+slashtext+tb)
+	run_in_shell("mkdir amcl"+slashtext+tb)
 
-	os.system(copytext+"big.swift "+fpath+"big.swift")
-	os.system(copytext+"config_big.swift "+fpath+"config_big.swift")
-	os.system(copytext+"config_ff.swift "+fpath+"config_ff.swift")
-	os.system(copytext+"dbig.swift "+fpath+"dbig.swift")
-	os.system(copytext+"ff.swift "+fpath+"ff.swift")
-	os.system(copytext+"rsa.swift "+fpath+"rsa.swift")
+	run_in_shell(copytext+"big.swift "+fpath+"big.swift")
+	run_in_shell(copytext+"config_big.swift "+fpath+"config_big.swift")
+	run_in_shell(copytext+"config_ff.swift "+fpath+"config_ff.swift")
+	run_in_shell(copytext+"dbig.swift "+fpath+"dbig.swift")
+	run_in_shell(copytext+"ff.swift "+fpath+"ff.swift")
+	run_in_shell(copytext+"rsa.swift "+fpath+"rsa.swift")
 
 	replace(fpath+"config_big.swift","@NB@",nb)
 	replace(fpath+"config_big.swift","@BASE32@",base)
@@ -52,9 +56,9 @@ def rsaset(tb,nb,base,ml) :
 
 	replace(fpath+"config_ff.swift","@ML@",ml)
 
-	os.system("swiftc -DD64 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
-	os.system(deltext+fpath+"*.*")
-	os.system("rmdir amcl"+slashtext+tb)
+	run_in_shell("swiftc -DD64 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tb)
+	run_in_shell(deltext+fpath+"*.*")
+	run_in_shell("rmdir amcl"+slashtext+tb)
 
 
 def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
@@ -65,16 +69,16 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	cptr=cptr+1
 
 	fpath="amcl"+slashtext+tc+slashtext
-	os.system("mkdir amcl"+slashtext+tc)
+	run_in_shell("mkdir amcl"+slashtext+tc)
 
-	os.system(copytext+"big.swift "+fpath+"big.swift")
-	os.system(copytext+"config_big.swift "+fpath+"config_big.swift")
-	os.system(copytext+"config_field.swift "+fpath+"config_field.swift")
-	os.system(copytext+"config_curve.swift "+fpath+"config_curve.swift")
-	os.system(copytext+"dbig.swift "+fpath+"dbig.swift")
-	os.system(copytext+"fp.swift "+fpath+"fp.swift")
-	os.system(copytext+"ecp.swift "+fpath+"ecp.swift")
-	os.system(copytext+"rom_"+tc+".swift "+fpath+"rom.swift")
+	run_in_shell(copytext+"big.swift "+fpath+"big.swift")
+	run_in_shell(copytext+"config_big.swift "+fpath+"config_big.swift")
+	run_in_shell(copytext+"config_field.swift "+fpath+"config_field.swift")
+	run_in_shell(copytext+"config_curve.swift "+fpath+"config_curve.swift")
+	run_in_shell(copytext+"dbig.swift "+fpath+"dbig.swift")
+	run_in_shell(copytext+"fp.swift "+fpath+"fp.swift")
+	run_in_shell(copytext+"ecp.swift "+fpath+"ecp.swift")
+	run_in_shell(copytext+"rom_"+tc+".swift "+fpath+"rom.swift")
 
 	replace(fpath+"config_big.swift","@NB@",nb)
 	replace(fpath+"config_big.swift","@BASE32@",base)
@@ -110,48 +114,48 @@ def curveset(tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		replace(fpath+"config_curve.swift","@AK@","32")
 
 	if pf != "NOT" :
-		os.system(copytext+"fp2.swift "+fpath+"fp2.swift")
-		os.system(copytext+"fp4.swift "+fpath+"fp4.swift")
+		run_in_shell(copytext+"fp2.swift "+fpath+"fp2.swift")
+		run_in_shell(copytext+"fp4.swift "+fpath+"fp4.swift")
 		if cs == "128" :
-			os.system(copytext+"ecp2.swift "+fpath+"ecp2.swift")
-			os.system(copytext+"fp12.swift "+fpath+"fp12.swift")
-			os.system(copytext+"pair.swift "+fpath+"pair.swift")
-			os.system(copytext+"mpin.swift "+fpath+"mpin.swift")
-			os.system(copytext+"bls.swift "+fpath+"bls.swift")
+			run_in_shell(copytext+"ecp2.swift "+fpath+"ecp2.swift")
+			run_in_shell(copytext+"fp12.swift "+fpath+"fp12.swift")
+			run_in_shell(copytext+"pair.swift "+fpath+"pair.swift")
+			run_in_shell(copytext+"mpin.swift "+fpath+"mpin.swift")
+			run_in_shell(copytext+"bls.swift "+fpath+"bls.swift")
 		if cs == "192" :
-			os.system(copytext+"fp8.swift "+fpath+"fp8.swift")
-			os.system(copytext+"ecp4.swift "+fpath+"ecp4.swift")
-			os.system(copytext+"fp24.swift "+fpath+"fp24.swift")
-			os.system(copytext+"pair192.swift "+fpath+"pair192.swift")
-			os.system(copytext+"mpin192.swift "+fpath+"mpin192.swift")
-			os.system(copytext+"bls192.swift "+fpath+"bls192.swift")
+			run_in_shell(copytext+"fp8.swift "+fpath+"fp8.swift")
+			run_in_shell(copytext+"ecp4.swift "+fpath+"ecp4.swift")
+			run_in_shell(copytext+"fp24.swift "+fpath+"fp24.swift")
+			run_in_shell(copytext+"pair192.swift "+fpath+"pair192.swift")
+			run_in_shell(copytext+"mpin192.swift "+fpath+"mpin192.swift")
+			run_in_shell(copytext+"bls192.swift "+fpath+"bls192.swift")
 		if cs == "256" :
-			os.system(copytext+"fp8.swift "+fpath+"fp8.swift")
-			os.system(copytext+"fp16.swift "+fpath+"fp16.swift")
-			os.system(copytext+"ecp8.swift "+fpath+"ecp8.swift")
-			os.system(copytext+"fp48.swift "+fpath+"fp48.swift")
-			os.system(copytext+"pair256.swift "+fpath+"pair256.swift")
-			os.system(copytext+"mpin256.swift "+fpath+"mpin256.swift")
-			os.system(copytext+"bls256.swift "+fpath+"bls256.swift")
+			run_in_shell(copytext+"fp8.swift "+fpath+"fp8.swift")
+			run_in_shell(copytext+"fp16.swift "+fpath+"fp16.swift")
+			run_in_shell(copytext+"ecp8.swift "+fpath+"ecp8.swift")
+			run_in_shell(copytext+"fp48.swift "+fpath+"fp48.swift")
+			run_in_shell(copytext+"pair256.swift "+fpath+"pair256.swift")
+			run_in_shell(copytext+"mpin256.swift "+fpath+"mpin256.swift")
+			run_in_shell(copytext+"bls256.swift "+fpath+"bls256.swift")
 
 	else :
-		os.system(copytext+"ecdh.swift "+fpath+"ecdh.swift")
+		run_in_shell(copytext+"ecdh.swift "+fpath+"ecdh.swift")
 
 
-	os.system("swiftc -DD64 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tc)
-	os.system(deltext+fpath+"*.*")
-	os.system("rmdir amcl"+slashtext+tc)
+	run_in_shell("swiftc -DD64 "+fpath+"*.swift -L. -lamcl -I. -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name "+tc)
+	run_in_shell(deltext+fpath+"*.*")
+	run_in_shell("rmdir amcl"+slashtext+tc)
 
 
-os.system("mkdir amcl")
-os.system(copytext+ "hash*.swift amcl"+slashtext+".")
-os.system(copytext+ "sha3.swift amcl"+slashtext+".")
-os.system(copytext+ "rand.swift amcl"+slashtext+".")
-os.system(copytext+ "aes.swift amcl"+slashtext+".")
-os.system(copytext+ "gcm.swift amcl"+slashtext+".")
-os.system(copytext+ "nhs.swift amcl"+slashtext+".")
+run_in_shell("mkdir amcl")
+run_in_shell(copytext+ "hash*.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "sha3.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "rand.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "aes.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "gcm.swift amcl"+slashtext+".")
+run_in_shell(copytext+ "nhs.swift amcl"+slashtext+".")
 
-os.system("swiftc amcl"+slashtext+"*.swift -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name amcl")
+run_in_shell("swiftc amcl"+slashtext+"*.swift -O -Ounchecked -whole-module-optimization -emit-library -emit-module -module-name amcl")
 
 print("Elliptic Curves")
 print("1. ed25519")
@@ -334,29 +338,29 @@ while ptr<max:
 		rsaset("rsa4096","64","60","8")
 		rsa_selected=True
 
-os.system(deltext+" hash*.swift")
-os.system(deltext+" sha3.swift")
-os.system(deltext+" aes.swift")
-os.system(deltext+" rand.swift")
-os.system(deltext+" gcm.swift")
-os.system(deltext+" nhs.swift")
+run_in_shell(deltext+" hash*.swift")
+run_in_shell(deltext+" sha3.swift")
+run_in_shell(deltext+" aes.swift")
+run_in_shell(deltext+" rand.swift")
+run_in_shell(deltext+" gcm.swift")
+run_in_shell(deltext+" nhs.swift")
 
-os.system(deltext+" big.swift")
-os.system(deltext+" dbig.swift")
-os.system(deltext+" fp*.swift")
-os.system(deltext+" config*.swift")
+run_in_shell(deltext+" big.swift")
+run_in_shell(deltext+" dbig.swift")
+run_in_shell(deltext+" fp*.swift")
+run_in_shell(deltext+" config*.swift")
 
-os.system(deltext+" ecp*.swift")
-os.system(deltext+" ecdh.swift")
-os.system(deltext+" ff.swift")
-os.system(deltext+" rsa.swift")
-os.system(deltext+" pair*.swift")
-os.system(deltext+" mpin*.swift")
-os.system(deltext+" bls*.swift")
-os.system(deltext+" rom*.swift")
+run_in_shell(deltext+" ecp*.swift")
+run_in_shell(deltext+" ecdh.swift")
+run_in_shell(deltext+" ff.swift")
+run_in_shell(deltext+" rsa.swift")
+run_in_shell(deltext+" pair*.swift")
+run_in_shell(deltext+" mpin*.swift")
+run_in_shell(deltext+" bls*.swift")
+run_in_shell(deltext+" rom*.swift")
 
-os.system(deltext+"amcl"+slashtext+"*.*")
-os.system("rmdir amcl")
+run_in_shell(deltext+"amcl"+slashtext+"*.*")
+run_in_shell("rmdir amcl")
 
 # create library
 

--- a/version3/wasm/config.py
+++ b/version3/wasm/config.py
@@ -36,7 +36,7 @@ def rsaset(tb,tff,nb,base,ml) :
 	os.system(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
-	replace(fnameh,"@ML@",ml);
+	replace(fnameh,"@ML@",ml)
 
 	fnamec="big_"+bd+".c"
 	fnamebc="big_"+bd+".bc"
@@ -141,7 +141,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
 
-	os.system("emcc -O2 rom_field_"+tf+".c -o rom_field_"+tf+".bc");
+	os.system("emcc -O2 rom_field_"+tf+".c -o rom_field_"+tf+".bc")
 
 	fnamec="ecp_"+tc+".c"
 	fnamebc="ecp_"+tc+".bc"
@@ -173,7 +173,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"XXX",bd)
 	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
 
-	os.system("emcc -O2 rom_curve_"+tc+".c -o rom_curve_"+tc+".bc");
+	os.system("emcc -O2 rom_curve_"+tc+".c -o rom_curve_"+tc+".bc")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
@@ -522,13 +522,13 @@ while ptr<max:
 			break
 	if already:
 		continue
-	
+
 	selection.append(x)
 	ptr=ptr+1
 
 # curveset(big,field,curve,big_length_bytes,bits_in_base,modulus_bits,modulus_mod_8,modulus_type,curve_type,pairing_friendly,sextic twist,sign of x,ate bits,curve security)
-# for each curve give names for big, field and curve. In many cases the latter two will be the same. 
-# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve   
+# for each curve give names for big, field and curve. In many cases the latter two will be the same.
+# Typically "big" is the size in bits, always a multiple of 8, "field" describes the modulus, and "curve" is the common name for the elliptic curve
 # big_length_bytes is "big" divided by 8
 # Next give the number base used for 32 bit architectures, as n where the base is 2^n (note that these must be fixed for the same "big" name, if is ever re-used for another curve)
 # modulus_bits is the bit length of the modulus, typically the same or slightly smaller than "big"
@@ -719,7 +719,6 @@ else :
 	
 os.system(deltext+" *.bc")
 
-#print("Your section was ");	
+#print("Your section was ")
 #for i in range(0,ptr):
 #	print (selection[i])
-

--- a/version3/wasm/config.py
+++ b/version3/wasm/config.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 deltext=""
@@ -11,6 +12,9 @@ if sys.platform.startswith("darwin")  :
 if sys.platform.startswith("win") :
 	deltext="del"
 	copytext="copy"
+
+def run_in_shell(cmd):
+    subprocess.check_call(cmd, shell=True)
 
 def replace(namefile,oldtext,newtext):
 	f = open(namefile,'r')
@@ -27,13 +31,13 @@ def replace(namefile,oldtext,newtext):
 def rsaset(tb,tff,nb,base,ml) :
 	bd=tb+"_"+base
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
 	replace(fnameh,"@BASE@",base)
 
 	fnameh="config_ff_"+tff+".h"
-	os.system(copytext+" config_ff.h "+fnameh)
+	run_in_shell(copytext+" config_ff.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"@ML@",ml)
@@ -42,44 +46,44 @@ def rsaset(tb,tff,nb,base,ml) :
 	fnamebc="big_"+bd+".bc"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 	fnamec="ff_"+tff+".c"
 	fnamebc="ff_"+tff+".bc"
 	fnameh="ff_"+tff+".h"
 
-	os.system(copytext+" ff.c "+fnamec)
-	os.system(copytext+" ff.h "+fnameh)
+	run_in_shell(copytext+" ff.c "+fnamec)
+	run_in_shell(copytext+" ff.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 	fnamec="rsa_"+tff+".c"
 	fnamebc="rsa_"+tff+".bc"
 	fnameh="rsa_"+tff+".h"
 
-	os.system(copytext+" rsa.c "+fnamec)
-	os.system(copytext+" rsa.h "+fnameh)
+	run_in_shell(copytext+" rsa.c "+fnamec)
+	run_in_shell(copytext+" rsa.h "+fnameh)
 
 	replace(fnamec,"WWW",tff)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"WWW",tff)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	bd=tb+"_"+base
 
 	fnameh="config_big_"+bd+".h"
-	os.system(copytext+" config_big.h "+fnameh)
+	run_in_shell(copytext+" config_big.h "+fnameh)
 
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"@NB@",nb)
@@ -87,7 +91,7 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 
 
 	fnameh="config_field_"+tf+".h"
-	os.system(copytext+" config_field.h "+fnameh)
+	run_in_shell(copytext+" config_field.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"@NBT@",nbt)
@@ -104,8 +108,8 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 		sh=14
 	replace(fnameh,"@SH@",str(sh))
 
-	fnameh="config_curve_"+tc+".h"	
-	os.system(copytext+" config_curve.h "+fnameh)
+	fnameh="config_curve_"+tc+".h"
+	run_in_shell(copytext+" config_curve.h "+fnameh)
 	replace(fnameh,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"ZZZ",tc)
@@ -121,34 +125,34 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	fnamebc="big_"+bd+".bc"
 	fnameh="big_"+bd+".h"
 
-	os.system(copytext+" big.c "+fnamec)
-	os.system(copytext+" big.h "+fnameh)
+	run_in_shell(copytext+" big.c "+fnamec)
+	run_in_shell(copytext+" big.h "+fnameh)
 
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 	fnamec="fp_"+tf+".c"
 	fnamebc="fp_"+tf+".bc"
 	fnameh="fp_"+tf+".h"
 
-	os.system(copytext+" fp.c "+fnamec)
-	os.system(copytext+" fp.h "+fnameh)
+	run_in_shell(copytext+" fp.c "+fnamec)
+	run_in_shell(copytext+" fp.h "+fnameh)
 
 	replace(fnamec,"YYY",tf)
 	replace(fnamec,"XXX",bd)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
-	os.system("emcc -O2 rom_field_"+tf+".c -o rom_field_"+tf+".bc")
+	run_in_shell("emcc -O2 rom_field_"+tf+".c -o rom_field_"+tf+".bc")
 
 	fnamec="ecp_"+tc+".c"
 	fnamebc="ecp_"+tc+".bc"
 	fnameh="ecp_"+tc+".h"
 
-	os.system(copytext+" ecp.c "+fnamec)
-	os.system(copytext+" ecp.h "+fnameh)
+	run_in_shell(copytext+" ecp.c "+fnamec)
+	run_in_shell(copytext+" ecp.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -156,14 +160,14 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 	fnamec="ecdh_"+tc+".c"
 	fnamebc="ecdh_"+tc+".bc"
 	fnameh="ecdh_"+tc+".h"
 
-	os.system(copytext+" ecdh.c "+fnamec)
-	os.system(copytext+" ecdh.h "+fnameh)
+	run_in_shell(copytext+" ecdh.c "+fnamec)
+	run_in_shell(copytext+" ecdh.h "+fnameh)
 
 	replace(fnamec,"ZZZ",tc)
 	replace(fnamec,"YYY",tf)
@@ -171,36 +175,36 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 	replace(fnameh,"ZZZ",tc)
 	replace(fnameh,"YYY",tf)
 	replace(fnameh,"XXX",bd)
-	os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+	run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
-	os.system("emcc -O2 rom_curve_"+tc+".c -o rom_curve_"+tc+".bc")
+	run_in_shell("emcc -O2 rom_curve_"+tc+".c -o rom_curve_"+tc+".bc")
 
 	if pf != "NOT" :
 		fnamec="fp2_"+tf+".c"
 		fnamebc="fp2_"+tf+".bc"
 		fnameh="fp2_"+tf+".h"
 
-		os.system(copytext+" fp2.c "+fnamec)
-		os.system(copytext+" fp2.h "+fnameh)
+		run_in_shell(copytext+" fp2.c "+fnamec)
+		run_in_shell(copytext+" fp2.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
-		os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+		run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 		fnamec="fp4_"+tf+".c"
 		fnamebc="fp4_"+tf+".bc"
 		fnameh="fp4_"+tf+".h"
 
-		os.system(copytext+" fp4.c "+fnamec)
-		os.system(copytext+" fp4.h "+fnameh)
+		run_in_shell(copytext+" fp4.c "+fnamec)
+		run_in_shell(copytext+" fp4.h "+fnameh)
 		replace(fnamec,"YYY",tf)
 		replace(fnamec,"XXX",bd)
 		replace(fnamec,"ZZZ",tc)
 		replace(fnameh,"YYY",tf)
 		replace(fnameh,"XXX",bd)
 		replace(fnameh,"ZZZ",tc)
-		os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+		run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 		if cs == "128" :
@@ -208,71 +212,71 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			fnamebc="fp12_"+tf+".bc"
 			fnameh="fp12_"+tf+".h"
 
-			os.system(copytext+" fp12.c "+fnamec)
-			os.system(copytext+" fp12.h "+fnameh)
+			run_in_shell(copytext+" fp12.c "+fnamec)
+			run_in_shell(copytext+" fp12.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="ecp2_"+tc+".c"
 			fnamebc="ecp2_"+tc+".bc"
 			fnameh="ecp2_"+tc+".h"
 
-			os.system(copytext+" ecp2.c "+fnamec)
-			os.system(copytext+" ecp2.h "+fnameh)
+			run_in_shell(copytext+" ecp2.c "+fnamec)
+			run_in_shell(copytext+" ecp2.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="pair_"+tc+".c"
 			fnamebc="pair_"+tc+".bc"
 			fnameh="pair_"+tc+".h"
 
-			os.system(copytext+" pair.c "+fnamec)
-			os.system(copytext+" pair.h "+fnameh)
+			run_in_shell(copytext+" pair.c "+fnamec)
+			run_in_shell(copytext+" pair.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="mpin_"+tc+".c"
 			fnamebc="mpin_"+tc+".bc"
 			fnameh="mpin_"+tc+".h"
 
-			os.system(copytext+" mpin.c "+fnamec)
-			os.system(copytext+" mpin.h "+fnameh)
+			run_in_shell(copytext+" mpin.c "+fnamec)
+			run_in_shell(copytext+" mpin.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="bls_"+tc+".c"
 			fnamebc="bls_"+tc+".bc"
 			fnameh="bls_"+tc+".h"
 
-			os.system(copytext+" bls.c "+fnamec)
-			os.system(copytext+" bls.h "+fnameh)
+			run_in_shell(copytext+" bls.c "+fnamec)
+			run_in_shell(copytext+" bls.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 		if cs == "192" :
@@ -280,86 +284,86 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			fnamebc="fp8_"+tf+".bc"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 			fnamec="fp24_"+tf+".c"
 			fnamebc="fp24_"+tf+".bc"
 			fnameh="fp24_"+tf+".h"
 
-			os.system(copytext+" fp24.c "+fnamec)
-			os.system(copytext+" fp24.h "+fnameh)
+			run_in_shell(copytext+" fp24.c "+fnamec)
+			run_in_shell(copytext+" fp24.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="ecp4_"+tc+".c"
 			fnamebc="ecp4_"+tc+".bc"
 			fnameh="ecp4_"+tc+".h"
 
-			os.system(copytext+" ecp4.c "+fnamec)
-			os.system(copytext+" ecp4.h "+fnameh)
+			run_in_shell(copytext+" ecp4.c "+fnamec)
+			run_in_shell(copytext+" ecp4.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="pair192_"+tc+".c"
 			fnamebc="pair192_"+tc+".bc"
 			fnameh="pair192_"+tc+".h"
 
-			os.system(copytext+" pair192.c "+fnamec)
-			os.system(copytext+" pair192.h "+fnameh)
+			run_in_shell(copytext+" pair192.c "+fnamec)
+			run_in_shell(copytext+" pair192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="mpin192_"+tc+".c"
 			fnamebc="mpin192_"+tc+".bc"
 			fnameh="mpin192_"+tc+".h"
 
-			os.system(copytext+" mpin192.c "+fnamec)
-			os.system(copytext+" mpin192.h "+fnameh)
+			run_in_shell(copytext+" mpin192.c "+fnamec)
+			run_in_shell(copytext+" mpin192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)		
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="bls192_"+tc+".c"
 			fnamebc="bls192_"+tc+".bc"
 			fnameh="bls192_"+tc+".h"
 
-			os.system(copytext+" bls192.c "+fnamec)
-			os.system(copytext+" bls192.h "+fnameh)
+			run_in_shell(copytext+" bls192.c "+fnamec)
+			run_in_shell(copytext+" bls192.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)	
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 		if cs == "256" :
@@ -368,103 +372,103 @@ def curveset(tb,tf,tc,nb,base,nbt,m8,mt,ct,pf,stw,sx,ab,cs) :
 			fnamebc="fp8_"+tf+".bc"
 			fnameh="fp8_"+tf+".h"
 
-			os.system(copytext+" fp8.c "+fnamec)
-			os.system(copytext+" fp8.h "+fnameh)
+			run_in_shell(copytext+" fp8.c "+fnamec)
+			run_in_shell(copytext+" fp8.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 			fnamec="ecp8_"+tc+".c"
 			fnamebc="ecp8_"+tc+".bc"
 			fnameh="ecp8_"+tc+".h"
 
-			os.system(copytext+" ecp8.c "+fnamec)
-			os.system(copytext+" ecp8.h "+fnameh)
+			run_in_shell(copytext+" ecp8.c "+fnamec)
+			run_in_shell(copytext+" ecp8.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 			fnamec="fp16_"+tf+".c"
 			fnamebc="fp16_"+tf+".bc"
 			fnameh="fp16_"+tf+".h"
 
-			os.system(copytext+" fp16.c "+fnamec)
-			os.system(copytext+" fp16.h "+fnameh)
+			run_in_shell(copytext+" fp16.c "+fnamec)
+			run_in_shell(copytext+" fp16.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 			fnamec="fp48_"+tf+".c"
 			fnamebc="fp48_"+tf+".bc"
 			fnameh="fp48_"+tf+".h"
 
-			os.system(copytext+" fp48.c "+fnamec)
-			os.system(copytext+" fp48.h "+fnameh)
+			run_in_shell(copytext+" fp48.c "+fnamec)
+			run_in_shell(copytext+" fp48.h "+fnameh)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 
 			fnamec="pair256_"+tc+".c"
 			fnamebc="pair256_"+tc+".bc"
 			fnameh="pair256_"+tc+".h"
 
-			os.system(copytext+" pair256.c "+fnamec)
-			os.system(copytext+" pair256.h "+fnameh)
+			run_in_shell(copytext+" pair256.c "+fnamec)
+			run_in_shell(copytext+" pair256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="mpin256_"+tc+".c"
 			fnamebc="mpin256_"+tc+".bc"
 			fnameh="mpin256_"+tc+".h"
 
-			os.system(copytext+" mpin256.c "+fnamec)
-			os.system(copytext+" mpin256.h "+fnameh)
+			run_in_shell(copytext+" mpin256.c "+fnamec)
+			run_in_shell(copytext+" mpin256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)				
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 			fnamec="bls256_"+tc+".c"
 			fnamebc="bls256_"+tc+".bc"
 			fnameh="bls256_"+tc+".h"
 
-			os.system(copytext+" bls256.c "+fnamec)
-			os.system(copytext+" bls256.h "+fnameh)
+			run_in_shell(copytext+" bls256.c "+fnamec)
+			run_in_shell(copytext+" bls256.h "+fnameh)
 			replace(fnamec,"ZZZ",tc)
 			replace(fnamec,"YYY",tf)
 			replace(fnamec,"XXX",bd)
 			replace(fnameh,"ZZZ",tc)
 			replace(fnameh,"YYY",tf)
 			replace(fnameh,"XXX",bd)
-			os.system("emcc -O2 "+fnamec+" -o "+fnamebc)		
+			run_in_shell("emcc -O2 "+fnamec+" -o "+fnamebc)
 
 replace("arch.h","@WL@","32")
 print("Elliptic Curves")
@@ -656,68 +660,68 @@ while ptr<max:
 		rsa_selected=True
 
 
-os.system(deltext+" big.*")
-os.system(deltext+" fp.*")
-os.system(deltext+" ecp.*")
-os.system(deltext+" ecdh.*")
-os.system(deltext+" ff.*")
-os.system(deltext+" rsa.*")
-os.system(deltext+" config_big.h")
-os.system(deltext+" config_field.h")
-os.system(deltext+" config_curve.h")
-os.system(deltext+" config_ff.h")
-os.system(deltext+" fp2.*")
-os.system(deltext+" fp4.*")
-os.system(deltext+" fp8.*")
-os.system(deltext+" fp16.*")
+run_in_shell(deltext+" big.*")
+run_in_shell(deltext+" fp.*")
+run_in_shell(deltext+" ecp.*")
+run_in_shell(deltext+" ecdh.*")
+run_in_shell(deltext+" ff.*")
+run_in_shell(deltext+" rsa.*")
+run_in_shell(deltext+" config_big.h")
+run_in_shell(deltext+" config_field.h")
+run_in_shell(deltext+" config_curve.h")
+run_in_shell(deltext+" config_ff.h")
+run_in_shell(deltext+" fp2.*")
+run_in_shell(deltext+" fp4.*")
+run_in_shell(deltext+" fp8.*")
+run_in_shell(deltext+" fp16.*")
 
 
-os.system(deltext+" fp12.*")
-os.system(deltext+" fp24.*")
-os.system(deltext+" fp48.*")
+run_in_shell(deltext+" fp12.*")
+run_in_shell(deltext+" fp24.*")
+run_in_shell(deltext+" fp48.*")
 
-os.system(deltext+" ecp2.*")
-os.system(deltext+" ecp4.*")
-os.system(deltext+" ecp8.*")
+run_in_shell(deltext+" ecp2.*")
+run_in_shell(deltext+" ecp4.*")
+run_in_shell(deltext+" ecp8.*")
 
-os.system(deltext+" pair.*")
-os.system(deltext+" mpin.*")
-os.system(deltext+" bls.*")
+run_in_shell(deltext+" pair.*")
+run_in_shell(deltext+" mpin.*")
+run_in_shell(deltext+" bls.*")
 
-os.system(deltext+" pair192.*")
-os.system(deltext+" mpin192.*")
-os.system(deltext+" bls192.*")
+run_in_shell(deltext+" pair192.*")
+run_in_shell(deltext+" mpin192.*")
+run_in_shell(deltext+" bls192.*")
 
-os.system(deltext+" pair256.*")
-os.system(deltext+" mpin256.*")
-os.system(deltext+" bls256.*")
+run_in_shell(deltext+" pair256.*")
+run_in_shell(deltext+" mpin256.*")
+run_in_shell(deltext+" bls256.*")
 
 
 # create library
-os.system("emcc -O2  randapi.c -o randapi.bc")
+run_in_shell("emcc -O2  randapi.c -o randapi.bc")
 if curve_selected :
-	os.system("emcc -O2  ecdh_support.c -o ecdh_support.bc")
+	run_in_shell("emcc -O2  ecdh_support.c -o ecdh_support.bc")
 if rsa_selected :
-	os.system("emcc -O2  rsa_support.c -o rsa_support.bc")
+	run_in_shell("emcc -O2  rsa_support.c -o rsa_support.bc")
 if pfcurve_selected :
-	os.system("emcc -O2  pbc_support.c -o pbc_support.bc")
+	run_in_shell("emcc -O2  pbc_support.c -o pbc_support.bc")
 
-os.system("emcc -O2 hash.c -o hash.bc")
-os.system("emcc -O2 rand.c -o rand.bc")
-os.system("emcc -O2 oct.c -o oct.bc")
-os.system("emcc -O2 aes.c -o aes.bc")
-os.system("emcc -O2 gcm.c -o gcm.bc")
-os.system("emcc -O2 newhope.c -o newhope.bc")
+run_in_shell("emcc -O2 hash.c -o hash.bc")
+run_in_shell("emcc -O2 rand.c -o rand.bc")
+run_in_shell("emcc -O2 oct.c -o oct.bc")
+run_in_shell("emcc -O2 aes.c -o aes.bc")
+run_in_shell("emcc -O2 gcm.c -o gcm.bc")
+run_in_shell("emcc -O2 newhope.c -o newhope.bc")
 
 if sys.platform.startswith("win") :
-	os.system("for %i in (*.bc) do @echo %~nxi >> f.list")
-	os.system("emar rc amcl.a @f.list")
-	os.system(deltext+" f.list")
+	run_in_shell("for %i in (*.bc) do @echo %~nxi >> f.list")
+	run_in_shell("emar rc amcl.a @f.list")
+	run_in_shell(deltext+" f.list")
 
 else :
-	os.system("emar rc amcl.a *.bc")
-	
-os.system(deltext+" *.bc")
+	run_in_shell("emar rc amcl.a *.bc")
+
+run_in_shell(deltext+" *.bc")
 
 #print("Your section was ")
 #for i in range(0,ptr):


### PR DESCRIPTION
When the command in `os.system(cmd)` errored, the error was silently ignored. Now an exception is thrown and the configure scripts stop with a non-zero error code, making build systems aware of that.

See e.g.

```
$ python3
>>> import os, subprocess
>>> os.system("exit 5")
1280
>>> subprocess.check_call("exit 5", shell=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'exit 5' returned non-zero exit status 5.
```