### PR TITLE
Add java job to Travis build matrix 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{js,json,sh}]
+[*.{js,json,sh,xml}]
 indent_style = space
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: generic
 env:
   matrix:
     - AMCL_LANG=cpp
+    - AMCL_LANG=java
     - AMCL_LANG=js
     - AMCL_LANG=rust
     - AMCL_LANG=swift

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -6,6 +6,9 @@ case "$AMCL_LANG" in
   cpp)
     ./scripts/travis_cpp.sh
     ;;
+  java)
+    ./scripts/travis_java.sh
+    ;;
   js)
     ./scripts/travis_js.sh
     ;;

--- a/scripts/travis_java.sh
+++ b/scripts/travis_java.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+(
+  cd version3/java
+
+  python3 config64.py <<END_OF_INPUT
+1
+3
+7
+18
+20
+25
+26
+27
+0
+END_OF_INPUT
+
+  cd amcl
+  mvn clean install
+)

--- a/version3/java/README.md
+++ b/version3/java/README.md
@@ -1,26 +1,34 @@
+# AMCL for Java
+
 Namespaces are used to separate different curves.
 
-To build the library and see it in action, execute the python3 scripts 
-config32.py or config64.py (depending on whether you want a 32 or 
-64-bit build), and select the curves that you wish to support. The 
-configured library can be built using maven. 
+To build the library and see it in action, execute the python3 scripts
+config32.py or config64.py (depending on whether you want a 32 or
+64-bit build), and select the curves that you wish to support. The
+configured library can be built using maven.
 
-Tests will take a while to  run.
+Tests will take a while to run.
 
 As a quick example copy to a working directory and execute
 
+```
 py config64.py
+```
 
 or perhaps
 
+```
 python3 config64.py
+```
 
 Choose options 1, 3, 7, 18, 20, 25, 26 and 27, for example.
 
 Once the library is configured, you can compile and install with maven:
 
+```
 cd amcl
 mvn clean install
+```
 
 Testing will be carried out during the installation process.
 

--- a/version3/java/pom.xml
+++ b/version3/java/pom.xml
@@ -12,8 +12,8 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-<properties>
-<maven.compiler.source>1.6</maven.compiler.source>
-<maven.compiler.target>1.6</maven.compiler.target>
- </properties>
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
 </project>


### PR DESCRIPTION
Yet another language to be tested by Travis.

The bump of the Java language level was necessary to make my local Apache Maven 3.6.1 happy. However, I am not a Maven expert.