### PR TITLE
Make members of ECP, ECP2, FP2, FP12 public

### DIFF
--- a/version3/rust/src/ecp.rs
+++ b/version3/rust/src/ecp.rs
@@ -29,9 +29,9 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct ECP {
-    x: FP,
-    y: FP,
-    z: FP,
+    pub x: FP,
+    pub y: FP,
+    pub z: FP,
 }
 
 impl PartialEq for ECP {

--- a/version3/rust/src/ecp.rs
+++ b/version3/rust/src/ecp.rs
@@ -29,9 +29,9 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct ECP {
-    pub x: FP,
-    pub y: FP,
-    pub z: FP,
+    x: FP,
+    y: FP,
+    z: FP,
 }
 
 impl PartialEq for ECP {
@@ -353,6 +353,21 @@ impl ECP {
     pub fn getpz(&self) -> FP {
         let w = FP::new_copy(&self.z);
         return w;
+    }
+
+    /* replace x by given FP */
+    pub fn setpx(&mut self, x: FP) {
+        self.x = x
+    }
+
+    /* replace y by given FP */
+    pub fn setpy(&mut self, y: FP) {
+        self.y = y
+    }
+
+    /* replace z by given FP */
+    pub fn setpz(&mut self, z: FP) {
+        self.z = z
     }
 
     /* convert to byte array */

--- a/version3/rust/src/ecp2.rs
+++ b/version3/rust/src/ecp2.rs
@@ -28,9 +28,9 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct ECP2 {
-    x: FP2,
-    y: FP2,
-    z: FP2,
+    pub x: FP2,
+    pub y: FP2,
+    pub z: FP2,
 }
 
 impl PartialEq for ECP2 {

--- a/version3/rust/src/ecp2.rs
+++ b/version3/rust/src/ecp2.rs
@@ -28,9 +28,9 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct ECP2 {
-    pub x: FP2,
-    pub y: FP2,
-    pub z: FP2,
+    x: FP2,
+    y: FP2,
+    z: FP2,
 }
 
 impl PartialEq for ECP2 {
@@ -222,6 +222,21 @@ impl ECP2 {
     /* extract projective z */
     pub fn getpz(&self) -> FP2 {
         return FP2::new_copy(&self.z);
+    }
+
+    /* replace x by given FP2 */
+    pub fn setpx(&mut self, x: FP2) {
+        self.x = x
+    }
+
+    /* replace y by given FP2 */
+    pub fn setpy(&mut self, y: FP2) {
+        self.y = y
+    }
+
+    /* replace z by given FP2 */
+    pub fn setpz(&mut self, z: FP2) {
+        self.z = z
     }
 
     /* convert to byte array */

--- a/version3/rust/src/fp12.rs
+++ b/version3/rust/src/fp12.rs
@@ -34,10 +34,10 @@ pub const DENSE: usize=4;
 
 #[derive(Copy, Clone)]
 pub struct FP12 {
-    a: FP4,
-    b: FP4,
-    c: FP4,
-    stype: usize,
+    pub a: FP4,
+    pub b: FP4,
+    pub c: FP4,
+    pub stype: usize,
 }
 
 impl PartialEq for FP12 {

--- a/version3/rust/src/fp12.rs
+++ b/version3/rust/src/fp12.rs
@@ -34,10 +34,10 @@ pub const DENSE: usize=4;
 
 #[derive(Copy, Clone)]
 pub struct FP12 {
-    pub a: FP4,
-    pub b: FP4,
-    pub c: FP4,
-    pub stype: usize,
+    a: FP4,
+    b: FP4,
+    c: FP4,
+    stype: usize,
 }
 
 impl PartialEq for FP12 {
@@ -189,6 +189,21 @@ impl FP12 {
         return self.c;
 //        let f = FP4::new_copy(&self.c);
 //        return f;
+    }
+
+    /* replace a by given FP4 */
+    pub fn seta(&mut self, a: FP4) {
+        self.a = a
+    }
+
+    /* replace b by given FP4 */
+    pub fn setb(&mut self, b: FP4) {
+        self.b = b
+    }
+
+    /* replace c by given FP4 */
+    pub fn setc(&mut self, c: FP4) {
+        self.c = c
     }
 
     /* copy self=x */

--- a/version3/rust/src/fp2.rs
+++ b/version3/rust/src/fp2.rs
@@ -27,8 +27,8 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct FP2 {
-    a: FP,
-    b: FP,
+    pub a: FP,
+    pub b: FP,
 }
 
 impl PartialEq for FP2 {

--- a/version3/rust/src/fp2.rs
+++ b/version3/rust/src/fp2.rs
@@ -27,8 +27,8 @@ use std::fmt;
 
 #[derive(Copy, Clone)]
 pub struct FP2 {
-    pub a: FP,
-    pub b: FP,
+    a: FP,
+    b: FP,
 }
 
 impl PartialEq for FP2 {
@@ -140,6 +140,16 @@ impl FP2 {
     /* extract b */
     pub fn getb(&mut self) -> BIG {
         return self.b.redc();
+    }
+
+    /* replace a by given FP */
+    pub fn seta(&mut self, a: FP) {
+        self.a = a
+    }
+
+    /* replace b by given FP */
+    pub fn setb(&mut self, b: FP) {
+        self.b = b
     }
 
     /* copy self=x */

--- a/version3/rust/src/fp4.rs
+++ b/version3/rust/src/fp4.rs
@@ -135,6 +135,16 @@ impl FP4 {
 //        return f;
     }
 
+    /* replace a by given FP2 */
+    pub fn seta(&mut self, a: FP2) {
+        self.a = a
+    }
+
+    /* replace b by given FP2 */
+    pub fn setb(&mut self, b: FP2) {
+        self.b = b
+    }
+
     /* test self=x */
     pub fn equals(&self, x: &FP4) -> bool {
         return self.a.equals(&x.a) && self.b.equals(&x.b);


### PR DESCRIPTION
Signed-off-by: lovesh <lovesh.bond@gmail.com>

These are needed for 2 kinds of operations. One is for zeroing after uses. When these are used  in structs and then those structs need to be zeroed out, there does not seem to be a clear way. On `ECP*`, `inf` can be used as a workaround though. The other usage is deserialization. `from_hex` on `BIG`, `ECP` and `ECP2`, does not do input validation and is not constant time. So, i wrote some methods in my code to handle those duplicating most of the logic in `from_hex` like for [BIG](https://github.com/lovesh/amcl_rust_wrapper/blob/remove-copying/src/field_elem.rs#L413), for [FP](https://github.com/lovesh/amcl_rust_wrapper/blob/remove-copying/src/group_elem_g1.rs#L158) and for [FP2](https://github.com/lovesh/amcl_rust_wrapper/blob/remove-copying/src/group_elem_g2.rs#L135). But to recreate ECP or ECP2, i need to be able to populate them with `FP`s and `FP2`s. I am currently using some forked code to achieve that.
I would like to contribute the deserialization changes back but that would make amcl return errors.