### PR TITLE
Re-enable AMCL_LANG=wasm-rust Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - AMCL_LANG=rust
     - AMCL_LANG=swift
     - AMCL_LANG=wasm-c
-#   - AMCL_LANG=wasm-rust
+    - AMCL_LANG=wasm-rust
 
 script:
   - ./scripts/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
     - AMCL_LANG=wasm-c
     - AMCL_LANG=wasm-rust
 
+matrix:
+  allow_failures:
+    - env: AMCL_LANG=wasm-rust
+
 script:
   - ./scripts/travis.sh
 


### PR DESCRIPTION
The link error

```
    Finished release [optimized] target(s) in 51.77s
error: linking with `emcc` failed: exit code: 1
  |
  = note: "emcc" "-s" "DISABLE_EXCEPTION_CATCHING=0" "-L" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib" "TestALL.TestALL.7rcbfp3g-cgu.0.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.1.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.10.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.11.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.12.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.13.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.14.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.15.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.2.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.3.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.4.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.5.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.6.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.7.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.8.rcgu.o" "TestALL.TestALL.7rcbfp3g-cgu.9.rcgu.o" "-o" "TestALL.html" "-s" "EXPORTED_FUNCTIONS=[\"_main\",\"_rust_eh_personality\"]" "TestALL.ftqyzuztw7ihyjc.rcgu.o" "-O2" "--memory-init-file" "0" "-g0" "-s" "DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[]" "-L" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib" "/home/travis/build/miracl/amcl/build-wasm-rust/libamcl.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libstd-c3a1268b0ca58abc.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libpanic_unwind-df99b38c13845e6b.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libhashbrown-5fda646f3f7147a3.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_std_workspace_alloc-cab185f0e95eb268.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libbacktrace-d3b692abbef8a71e.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_demangle-1c6566ea50b74fdf.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libunwind-392f9aee3071b376.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcfg_if-c650f0067a17f672.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/liblibc-5a609febbc798595.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/liballoc-2875889606754491.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_std_workspace_core-09b2dd65fc6b549e.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcore-8d39f774f75d50c8.rlib" "/home/travis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcompiler_builtins-f1ee5b04877823a0.rlib" "-l" "c" "-s" "BINARYEN=1" "-s" "ERROR_ON_UNDEFINED_SYMBOLS=1" "-s" "BINARYEN_TRAP_MODE=\'clamp\'"
  = note: shared:ERROR: BINARYEN_TRAP_MODE is not supported by the LLVM wasm backend

error: aborting due to previous error
```

was probably caused by emscripten/emsdk, since we never define `BINARYEN_TRAP_MODE`. Let's see if they fixed this in the meantime.