### PR TITLE
Fix issue with fp512bn on 32 to bit OS

### DIFF
--- a/version3/rust/src/roms/rom_fp512bn_32.rs
+++ b/version3/rust/src/roms/rom_fp512bn_32.rs
@@ -232,8 +232,8 @@ pub const USE_GS_G2: bool = true;
 pub const USE_GS_GT: bool = true;
 pub const GT_STRONG: bool = false;
 
-pub const MODBYTES: usize = 32;
-pub const BASEBITS: usize = 28;
+pub const MODBYTES: usize = 64;
+pub const BASEBITS: usize = 29;
 
 pub const MODBITS: usize = 512;
 pub const MOD8: usize = 3;


### PR DESCRIPTION
# What is the issue

The modulus bits and base bits were incorrectly setup on `fp512bn` for the 32 bit OS.