### PR TITLE
Arch.h

### DIFF
--- a/version3/cpp/arch.h
+++ b/version3/cpp/arch.h
@@ -47,13 +47,13 @@ namespace amcl {
 /* Support for C99?  Note for GCC need to explicitly include -std=c99 in command line */
 
 
-#define byte uint8_t			/**< 8-bit unsigned integer */
-#define sign8 int8_t			/**< 8-bit signed integer */
-#define sign16 int16_t			/**< 16-bit signed integer */
-#define sign32 int32_t			/**< 32-bit signed integer */
-#define sign64 int64_t			/**< 64-bit signed integer */
-#define unsign32 uint32_t		/**< 32-bit unsigned integer */
-#define unsign64 uint64_t		/**< 64-bit unsigned integer */
+using byte = uint8_t;			/**< 8-bit unsigned integer */
+using sign8 = int8_t;			/**< 8-bit signed integer */
+using sign16 = int16_t;			/**< 16-bit signed integer */
+using sign32 = int32_t;			/**< 32-bit signed integer */
+using sign64 = int64_t;			/**< 64-bit signed integer */
+using unsign32 = uint32_t;		/**< 32-bit unsigned integer */
+using unsign64 = uint64_t;		/**< 64-bit unsigned integer */
 
 #define uchar unsigned char  /**<  Unsigned char */
 


### PR DESCRIPTION
changed defines for types in arch.h to using - otherwise if someone includes the arch.h and declares a variable named byte the compiler will throw an error (e.g. int byte = 0;). 